### PR TITLE
[Debug/48-hotfix]: 공지 사항 파일 첨부 업로드 / 조회 버그 수정, 테스트

### DIFF
--- a/src/main/java/com/snut_likelion/domain/file/service/FileUploadService.java
+++ b/src/main/java/com/snut_likelion/domain/file/service/FileUploadService.java
@@ -187,12 +187,20 @@ public class FileUploadService {
     }
 
     /**
-     * storedFileName(S3 key) → 접근 가능한 URL로 변환한다.
-     * 조회 응답 DTO에서 key를 URL로 바꿀 때 사용한다.
+     * storedFileName(S3 key) → 이미지 접근 URL로 변환한다.
      * ex) "images/blogs/uuid-name.png" → "https://bucket.s3.../images/blogs/uuid-name.png"
      */
     public String buildFileUrl(String storedFileName) {
         return fileProvider.buildImageUrl(storedFileName);
+    }
+
+    /**
+     * storedFileName(S3 key) → 파일 다운로드 URL로 변환한다.
+     * ex) "files/notices/uuid-name.pdf" → "/api/v1/files/download?fileName=..." (dev)
+     *                                   → "https://bucket.s3.../files/notices/..." (prod)
+     */
+    public String buildFileDownloadUrl(String storedFileName) {
+        return fileProvider.buildFileDownloadUrl(storedFileName);
     }
 
 

--- a/src/main/java/com/snut_likelion/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/snut_likelion/domain/notice/service/NoticeService.java
@@ -170,7 +170,9 @@ public class NoticeService {
         return attachments.stream()
                 .collect(Collectors.toMap(
                         NoticeAttachment::getStoredFileName,
-                        a -> fileUploadService.buildFileUrl(a.getStoredFileName())
+                        a -> a.getAttachmentType() == AttachmentType.FILE
+                                ? fileUploadService.buildFileDownloadUrl(a.getStoredFileName())
+                                : fileUploadService.buildFileUrl(a.getStoredFileName())
                 ));
     }
 }

--- a/src/main/java/com/snut_likelion/global/provider/FileProvider.java
+++ b/src/main/java/com/snut_likelion/global/provider/FileProvider.java
@@ -28,4 +28,6 @@ public interface FileProvider {
     String extractImageName(String imageUrl);
 
     String buildImageUrl(String storedFileName);
+
+    String buildFileDownloadUrl(String storedFileName);
 }

--- a/src/main/java/com/snut_likelion/infra/file/LocalFileProvider.java
+++ b/src/main/java/com/snut_likelion/infra/file/LocalFileProvider.java
@@ -117,6 +117,11 @@ public class LocalFileProvider implements FileProvider {
         return String.format("%s/api/v1/images?imageName=%s", serverUrl, storedFileName);
     }
 
+    @Override
+    public String buildFileDownloadUrl(String storedFileName) {
+        return String.format("%s/api/v1/files/download?fileName=%s", serverUrl, storedFileName);
+    }
+
     private void validateStoredFileName(String storedFileName) {
         if (storedFileName == null || storedFileName.isBlank()) {
             throw new BadRequestException(FileErrorCode.INVALID_FILE_KEY);

--- a/src/main/java/com/snut_likelion/infra/file/LocalPresignedController.java
+++ b/src/main/java/com/snut_likelion/infra/file/LocalPresignedController.java
@@ -36,8 +36,10 @@ public class LocalPresignedController {  // Dev용 가짜 S3
             HttpServletRequest request
     ) {
         try {
-            // 1. 보안 검사: key는 반드시 images/로 시작해야 함 & 상위폴더 이동(..) 금지
-            if (key == null || key.isBlank() || !key.startsWith("images/") || key.contains("..")) {
+            // 1. 보안 검사: key는 반드시 images/ 또는 files/로 시작해야 함 & 상위폴더 이동(..) 금지
+            if (key == null || key.isBlank()
+                    || (!key.startsWith("images/") && !key.startsWith("files/"))
+                    || key.contains("..")) {
                 log.warn("[Local S3] Invalid key: {}", key);
                 return ResponseEntity.badRequest().build();
             }

--- a/src/main/java/com/snut_likelion/infra/file/S3FileProvider.java
+++ b/src/main/java/com/snut_likelion/infra/file/S3FileProvider.java
@@ -119,4 +119,9 @@ public class S3FileProvider implements FileProvider {
                 region,
                 key);
     }
+
+    @Override
+    public String buildFileDownloadUrl(String key) {
+        return buildImageUrl(key);
+    }
 }

--- a/src/test/java/com/snut_likelion/infra/file/LocalPresignedControllerTest.java
+++ b/src/test/java/com/snut_likelion/infra/file/LocalPresignedControllerTest.java
@@ -1,0 +1,73 @@
+package com.snut_likelion.infra.file;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.nio.file.Path;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LocalPresignedControllerTest {
+
+    @TempDir
+    Path tempDir;
+
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        LocalPresignedController controller = new LocalPresignedController(tempDir.toString());
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void files_prefix_key는_200을_반환한다() throws Exception {
+        mockMvc.perform(
+                put("/api/v1/files/local/presigned-put")
+                        .param("key", "files/notices/uuid-sample.pdf")
+                        .contentType("application/pdf")
+                        .content("dummy content")
+        ).andExpect(status().isOk());
+    }
+
+    @Test
+    void images_prefix_key는_200을_반환한다() throws Exception {
+        mockMvc.perform(
+                put("/api/v1/files/local/presigned-put")
+                        .param("key", "images/notices/uuid-sample.png")
+                        .contentType("image/png")
+                        .content("dummy content")
+        ).andExpect(status().isOk());
+    }
+
+    @Test
+    void 허용되지_않는_prefix_key는_400을_반환한다() throws Exception {
+        mockMvc.perform(
+                put("/api/v1/files/local/presigned-put")
+                        .param("key", "other/notices/uuid-sample.pdf")
+                        .content("dummy content")
+        ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 경로_탈출_시도는_400을_반환한다() throws Exception {
+        mockMvc.perform(
+                put("/api/v1/files/local/presigned-put")
+                        .param("key", "images/../etc/passwd")
+                        .content("dummy content")
+        ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 빈_key는_400을_반환한다() throws Exception {
+        mockMvc.perform(
+                put("/api/v1/files/local/presigned-put")
+                        .param("key", "")
+                        .content("dummy content")
+        ).andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Summary
- Dev 환경에서 files/ prefix key가 400으로 차단되어 파일 업로드가 불가능했던 버그 수정
- 파일 첨부 조회 시 이미지 URL 빌더가 사용되어 파일 다운로드 URL이 잘못 생성되던 버그 수정
- FileProvider에 buildFileDownloadUrl 추가, NoticeService에서 첨부 타입별 URL 분기 처리

## Test
- LocalPresignedControllerTest — 5개 케이스 추가 (files/images 허용, 잘못된 prefix/경로탈출/빈 key 차단


## 관련 이슈 번호
> - #48
