### PR TITLE
[Fix/40-ai]: 챗봇 접근 권한 수정

### DIFF
--- a/src/main/java/com/snut_likelion/global/auth/PermitAllUrls.java
+++ b/src/main/java/com/snut_likelion/global/auth/PermitAllUrls.java
@@ -38,6 +38,8 @@ public enum PermitAllUrls {
     GET_NOTICES("/api/v1/notices", GET),
     GET_NOTICE_DETAIL("/api/v1/notices/{noticeId}", GET),
 
+    AI_CHAT("/api/v1/ai/chat", POST),
+
     LOCAL_PRESIGNED_PUT("/api/v1/files/local/presigned-put", PUT),
 
     /* Swagger UI 관련 */

--- a/src/test/java/com/snut_likelion/ai/controller/AiControllerSecurityTest.java
+++ b/src/test/java/com/snut_likelion/ai/controller/AiControllerSecurityTest.java
@@ -1,0 +1,60 @@
+package com.snut_likelion.ai.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snut_likelion.ai.dto.res.AiChatResult;
+import com.snut_likelion.ai.service.AiQueryService;
+import com.snut_likelion.global.auth.jwt.JwtService;
+import com.snut_likelion.global.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AiController.class)
+@Import(SecurityConfig.class)
+class AiControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AiQueryService aiQueryService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @MockBean
+    private AuthenticationProvider authenticationProvider;
+
+    @Test
+    void chat_withoutAuthentication_returnsOk() throws Exception {
+        // Given
+        AiChatResult result = AiChatResult.of("answer", "intent-key", 0.9);
+        when(aiQueryService.chat(anyString())).thenReturn(result);
+
+        String requestBody = objectMapper.writeValueAsString(new TestTextRequest("질문"));
+
+        // When & Then — 비로그인(토큰 없음)에서도 200 응답이어야 한다
+        mockMvc.perform(post("/api/v1/ai/chat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("OK"));
+    }
+
+    private record TestTextRequest(String text) {
+    }
+}


### PR DESCRIPTION
## 개요
> kayo2e AI 챗봇 서버와 연동하여 질문-답변 매핑 기반의 챗봇 API를 제공합니다. 비로그인 사용자도 챗봇을 이용할 수
있습니다.

## 작업 내용
- [x] OpenFeign + Apache POI 의존성 추가 및 설정
- [x] AI 서버 호출용 FeignClient 및 외부 DTO 추가
- [x] 엑셀 기반 intent-answer 매핑 캐시 구현
- [x] Port-Adapter 구조의 AI 조회 서비스 구현 (`/api/v1/ai/chat`, `/api/v1/ai/summarize`)
- [x] chat 폴백 / summarize 예외 흐름 분리
- [x] `PermitAllUrls`에 `POST /api/v1/ai/chat` 추가 → 비로그인 접근 허용
- [x] 단위·통합·보안 테스트 작성

## 변경 유형
- [x] 기능 추가
- [x] 테스트

## 테스트
- [x] 단위 테스트 작성/확인 (AiService, AiAdapter, AiController)
- [x] 보안 테스트 작성 — 비로그인 POST `/api/v1/ai/chat` → 200 검증
- [ ] 로컬 실행 확인

## 관련 이슈
closes #40