### PR TITLE
[Release/40, 48]: AI 챗봇 연동 및 공지사항 파일 첨부 버그 수정 반영

### DIFF
--- a/src/main/java/com/snut_likelion/domain/file/service/FileUploadService.java
+++ b/src/main/java/com/snut_likelion/domain/file/service/FileUploadService.java
@@ -187,12 +187,20 @@ public class FileUploadService {
     }
 
     /**
-     * storedFileName(S3 key) → 접근 가능한 URL로 변환한다.
-     * 조회 응답 DTO에서 key를 URL로 바꿀 때 사용한다.
+     * storedFileName(S3 key) → 이미지 접근 URL로 변환한다.
      * ex) "images/blogs/uuid-name.png" → "https://bucket.s3.../images/blogs/uuid-name.png"
      */
     public String buildFileUrl(String storedFileName) {
         return fileProvider.buildImageUrl(storedFileName);
+    }
+
+    /**
+     * storedFileName(S3 key) → 파일 다운로드 URL로 변환한다.
+     * ex) "files/notices/uuid-name.pdf" → "/api/v1/files/download?fileName=..." (dev)
+     *                                   → "https://bucket.s3.../files/notices/..." (prod)
+     */
+    public String buildFileDownloadUrl(String storedFileName) {
+        return fileProvider.buildFileDownloadUrl(storedFileName);
     }
 
 

--- a/src/main/java/com/snut_likelion/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/snut_likelion/domain/notice/service/NoticeService.java
@@ -170,7 +170,9 @@ public class NoticeService {
         return attachments.stream()
                 .collect(Collectors.toMap(
                         NoticeAttachment::getStoredFileName,
-                        a -> fileUploadService.buildFileUrl(a.getStoredFileName())
+                        a -> a.getAttachmentType() == AttachmentType.FILE
+                                ? fileUploadService.buildFileDownloadUrl(a.getStoredFileName())
+                                : fileUploadService.buildFileUrl(a.getStoredFileName())
                 ));
     }
 }

--- a/src/main/java/com/snut_likelion/global/auth/PermitAllUrls.java
+++ b/src/main/java/com/snut_likelion/global/auth/PermitAllUrls.java
@@ -38,6 +38,8 @@ public enum PermitAllUrls {
     GET_NOTICES("/api/v1/notices", GET),
     GET_NOTICE_DETAIL("/api/v1/notices/{noticeId}", GET),
 
+    AI_CHAT("/api/v1/ai/chat", POST),
+
     LOCAL_PRESIGNED_PUT("/api/v1/files/local/presigned-put", PUT),
 
     /* Swagger UI 관련 */

--- a/src/main/java/com/snut_likelion/global/provider/FileProvider.java
+++ b/src/main/java/com/snut_likelion/global/provider/FileProvider.java
@@ -28,4 +28,6 @@ public interface FileProvider {
     String extractImageName(String imageUrl);
 
     String buildImageUrl(String storedFileName);
+
+    String buildFileDownloadUrl(String storedFileName);
 }

--- a/src/main/java/com/snut_likelion/infra/file/LocalFileProvider.java
+++ b/src/main/java/com/snut_likelion/infra/file/LocalFileProvider.java
@@ -117,6 +117,11 @@ public class LocalFileProvider implements FileProvider {
         return String.format("%s/api/v1/images?imageName=%s", serverUrl, storedFileName);
     }
 
+    @Override
+    public String buildFileDownloadUrl(String storedFileName) {
+        return String.format("%s/api/v1/files/download?fileName=%s", serverUrl, storedFileName);
+    }
+
     private void validateStoredFileName(String storedFileName) {
         if (storedFileName == null || storedFileName.isBlank()) {
             throw new BadRequestException(FileErrorCode.INVALID_FILE_KEY);

--- a/src/main/java/com/snut_likelion/infra/file/LocalPresignedController.java
+++ b/src/main/java/com/snut_likelion/infra/file/LocalPresignedController.java
@@ -36,8 +36,10 @@ public class LocalPresignedController {  // Dev용 가짜 S3
             HttpServletRequest request
     ) {
         try {
-            // 1. 보안 검사: key는 반드시 images/로 시작해야 함 & 상위폴더 이동(..) 금지
-            if (key == null || key.isBlank() || !key.startsWith("images/") || key.contains("..")) {
+            // 1. 보안 검사: key는 반드시 images/ 또는 files/로 시작해야 함 & 상위폴더 이동(..) 금지
+            if (key == null || key.isBlank()
+                    || (!key.startsWith("images/") && !key.startsWith("files/"))
+                    || key.contains("..")) {
                 log.warn("[Local S3] Invalid key: {}", key);
                 return ResponseEntity.badRequest().build();
             }

--- a/src/main/java/com/snut_likelion/infra/file/S3FileProvider.java
+++ b/src/main/java/com/snut_likelion/infra/file/S3FileProvider.java
@@ -119,4 +119,9 @@ public class S3FileProvider implements FileProvider {
                 region,
                 key);
     }
+
+    @Override
+    public String buildFileDownloadUrl(String key) {
+        return buildImageUrl(key);
+    }
 }

--- a/src/test/java/com/snut_likelion/ai/controller/AiControllerSecurityTest.java
+++ b/src/test/java/com/snut_likelion/ai/controller/AiControllerSecurityTest.java
@@ -1,0 +1,60 @@
+package com.snut_likelion.ai.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snut_likelion.ai.dto.res.AiChatResult;
+import com.snut_likelion.ai.service.AiQueryService;
+import com.snut_likelion.global.auth.jwt.JwtService;
+import com.snut_likelion.global.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AiController.class)
+@Import(SecurityConfig.class)
+class AiControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AiQueryService aiQueryService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @MockBean
+    private AuthenticationProvider authenticationProvider;
+
+    @Test
+    void chat_withoutAuthentication_returnsOk() throws Exception {
+        // Given
+        AiChatResult result = AiChatResult.of("answer", "intent-key", 0.9);
+        when(aiQueryService.chat(anyString())).thenReturn(result);
+
+        String requestBody = objectMapper.writeValueAsString(new TestTextRequest("질문"));
+
+        // When & Then — 비로그인(토큰 없음)에서도 200 응답이어야 한다
+        mockMvc.perform(post("/api/v1/ai/chat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("OK"));
+    }
+
+    private record TestTextRequest(String text) {
+    }
+}

--- a/src/test/java/com/snut_likelion/infra/file/LocalPresignedControllerTest.java
+++ b/src/test/java/com/snut_likelion/infra/file/LocalPresignedControllerTest.java
@@ -1,0 +1,73 @@
+package com.snut_likelion.infra.file;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.nio.file.Path;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class LocalPresignedControllerTest {
+
+    @TempDir
+    Path tempDir;
+
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        LocalPresignedController controller = new LocalPresignedController(tempDir.toString());
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void files_prefix_key는_200을_반환한다() throws Exception {
+        mockMvc.perform(
+                put("/api/v1/files/local/presigned-put")
+                        .param("key", "files/notices/uuid-sample.pdf")
+                        .contentType("application/pdf")
+                        .content("dummy content")
+        ).andExpect(status().isOk());
+    }
+
+    @Test
+    void images_prefix_key는_200을_반환한다() throws Exception {
+        mockMvc.perform(
+                put("/api/v1/files/local/presigned-put")
+                        .param("key", "images/notices/uuid-sample.png")
+                        .contentType("image/png")
+                        .content("dummy content")
+        ).andExpect(status().isOk());
+    }
+
+    @Test
+    void 허용되지_않는_prefix_key는_400을_반환한다() throws Exception {
+        mockMvc.perform(
+                put("/api/v1/files/local/presigned-put")
+                        .param("key", "other/notices/uuid-sample.pdf")
+                        .content("dummy content")
+        ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 경로_탈출_시도는_400을_반환한다() throws Exception {
+        mockMvc.perform(
+                put("/api/v1/files/local/presigned-put")
+                        .param("key", "images/../etc/passwd")
+                        .content("dummy content")
+        ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 빈_key는_400을_반환한다() throws Exception {
+        mockMvc.perform(
+                put("/api/v1/files/local/presigned-put")
+                        .param("key", "")
+                        .content("dummy content")
+        ).andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
 > AI 챗봇 연동 및 공지사항 파일 첨부 버그 수정을 포함한 릴리즈입니다.

  ## 작업 내용

  ### [#40] AI 챗봇 연동
  - [x] OpenFeign + Apache POI 의존성 추가 및 설정
  - [x] AI 서버 호출용 FeignClient 및 외부 DTO 추가
  - [x] 엑셀 기반 intent-answer 매핑 캐시 구현
  - [x] Port-Adapter 구조의 AI 조회 서비스 구현 (`/api/v1/ai/chat`, `/api/v1/ai/summarize`)
  - [x] chat 폴백 / summarize 예외 흐름 분리
  - [x] `PermitAllUrls`에 `POST /api/v1/ai/chat` 추가 → 비로그인 접근 허용
  - [x] 단위·통합·보안 테스트 작성

  ### [#48] 공지사항 파일 첨부 버그 수정
  - [x] dev 환경 Presigned PUT 업로드 차단 버그 수정
  - [x] 파일 조회 시 URL 오생성 버그 수정
  - [x] 이미지/일반 파일 타입 분기 누락 버그 수정
  - [x] `LocalPresignedController` 업로드 허용 테스트 추가
  - [x] `ProjectRetrospectionService` 회고 작성 테스트 추가

  ## 변경 유형
  - [x] 기능 추가
  - [x] 버그 수정
  - [x] 테스트

  ## 관련 이슈
  > -  #40
  > - #48