### PR TITLE
[Fix/#40-hotfix]: 공지사항 일반 파일 업로드 완료 시 key 검증 오류 수정

### DIFF
--- a/src/main/java/com/snut_likelion/admin/file/dto/req/CompleteFileUploadRequest.java
+++ b/src/main/java/com/snut_likelion/admin/file/dto/req/CompleteFileUploadRequest.java
@@ -1,5 +1,6 @@
 package com.snut_likelion.admin.file.dto.req;
 
+import com.snut_likelion.domain.file.dto.FileStorageType;
 import com.snut_likelion.domain.file.dto.UploadCategory;
 import com.snut_likelion.domain.file.entity.UploadedFile;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -39,6 +40,9 @@ public class CompleteFileUploadRequest {
     @Schema(description = "업로드 카테고리", example = "BLOG")
     @NotNull(message = "uploadCategory는 필수입니다.")
     private UploadCategory uploadCategory;
+
+    @Schema(description = "저장 유형. IMAGE → images/, FILE → files/ (기본값: IMAGE)", example = "IMAGE", nullable = true)
+    private FileStorageType fileStorageType = FileStorageType.IMAGE;
 
     public UploadedFile toEntity() {
         return UploadedFile.builder()

--- a/src/main/java/com/snut_likelion/admin/file/service/AdminFileUploadCommandService.java
+++ b/src/main/java/com/snut_likelion/admin/file/service/AdminFileUploadCommandService.java
@@ -24,6 +24,7 @@ public class AdminFileUploadCommandService {
     public CompleteFileUploadResponse completeUpload(CompleteFileUploadRequest req) {
         UploadedFile saved = fileUploadService.completeUpload(
                 req.getUploadCategory(),
+                req.getFileStorageType(),
                 req.getStoredFileName(),
                 req.getOriginalFileName(),
                 req.getContentType(),

--- a/src/main/java/com/snut_likelion/domain/file/service/FileUploadService.java
+++ b/src/main/java/com/snut_likelion/domain/file/service/FileUploadService.java
@@ -101,13 +101,14 @@ public class FileUploadService {
     @Transactional
     public UploadedFile completeUpload(
             UploadCategory category,
+            FileStorageType storageType,
             String storedFileName,
             String originalFileName,
             String contentType,
             long contentLength
     ) {
         // key 규칙 검증 (카테고리 폴더 prefix, ".." 금지)
-        validateKeyRule(storedFileName, category);
+        validateKeyRule(storedFileName, category, storageType);
 
         // 중복 등록 방지
         if (uploadedFileRepository.existsByStoredFileName(storedFileName)) {

--- a/src/test/java/com/snut_likelion/domain/file/service/FileUploadServiceTest.java
+++ b/src/test/java/com/snut_likelion/domain/file/service/FileUploadServiceTest.java
@@ -98,7 +98,7 @@ class FileUploadServiceTest {
 
         // When
         UploadedFile result = fileUploadService.completeUpload(
-                UploadCategory.BLOG, key, "photo.png", "image/png", 1024L
+                UploadCategory.BLOG, FileStorageType.IMAGE, key, "photo.png", "image/png", 1024L
         );
 
         // Then
@@ -114,7 +114,7 @@ class FileUploadServiceTest {
 
         // When / Then
         assertThatThrownBy(() -> fileUploadService.completeUpload(
-                UploadCategory.BLOG, key, "photo.png", "image/png", 1024L
+                UploadCategory.BLOG, FileStorageType.IMAGE, key, "photo.png", "image/png", 1024L
         )).isInstanceOf(ExistingResourceException.class);
     }
 
@@ -127,7 +127,7 @@ class FileUploadServiceTest {
 
         // When / Then
         assertThatThrownBy(() -> fileUploadService.completeUpload(
-                UploadCategory.BLOG, key, "photo.png", "image/png", 1024L
+                UploadCategory.BLOG, FileStorageType.IMAGE, key, "photo.png", "image/png", 1024L
         )).isInstanceOf(BadRequestException.class);
     }
 

--- a/src/test/java/com/snut_likelion/domain/notice/service/NoticeServiceTest.java
+++ b/src/test/java/com/snut_likelion/domain/notice/service/NoticeServiceTest.java
@@ -245,7 +245,7 @@ class NoticeServiceTest {
 
         when(noticeRepository.findByIdWithAttachments(1L)).thenReturn(Optional.of(notice));
         when(fileUploadService.buildFileUrl(IMG_KEY_1)).thenReturn(IMG_URL_1);
-        when(fileUploadService.buildFileUrl(FILE_KEY_1)).thenReturn(FILE_URL_1);
+        when(fileUploadService.buildFileDownloadUrl(FILE_KEY_1)).thenReturn(FILE_URL_1);
 
         // When
         NoticeDetailResponse response = noticeService.getNoticeDetail(1L);


### PR DESCRIPTION
## 개요
> 공지사항 일반 파일(PDF 등) 업로드 완료 시 key 검증 오류로 인한 BAD_REQUEST 버그 수정

## 작업 내용
- [x] `CompleteFileUploadRequest`에 `fileStorageType` 필드 추가 (기본값 `IMAGE`, 하위 호환)
- [x] `FileUploadService.completeUpload`에 `storageType` 파라미터 추가 → 올바른 prefix 검증
- [x] 관련 테스트 수정

## 변경 유형
- [x] 버그 수정
- [x] 테스트

## 테스트
- [x] 단위 테스트 수정/확인 (`FileUploadServiceTest`, `NoticeServiceTest`)
- [ ] 로컬 실행 확인

## 참고
프론트엔드에서 일반 파일 업로드 시 upload-complete 요청에 `"fileStorageType": "FILE"` 포함 필요

## 관련 이슈
closes #48