### PR TITLE
[Feat/68-alert]: 기수별 알림 기능 추가

### DIFF
--- a/src/main/java/com/snut_likelion/domain/recruitment/controller/SubscriptionController.java
+++ b/src/main/java/com/snut_likelion/domain/recruitment/controller/SubscriptionController.java
@@ -4,12 +4,14 @@ import com.snut_likelion.domain.recruitment.entity.SubscriptionType;
 import com.snut_likelion.domain.recruitment.service.SubscriptionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Subscription", description = "알림 구독 관리 API")
+@Tag(name = "Subscription", description = "모집 알림 구독 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/subscriptions")
@@ -17,15 +19,35 @@ public class SubscriptionController {
 
     private final SubscriptionService subscriptionService;
 
-    @Operation(summary = "알림 구독 등록", description = "특정 이메일에 대해 모집 알림 등의 구독 정보를 등록합니다.")
+    @Operation(
+            summary = "모집 알림 구독 등록",
+            description = """
+                    비회원이 특정 기수 모집 시작 알림을 이메일로 받기 위해 구독을 등록합니다.
+
+                    - `type=MEMBER`: 아기사자 모집 알림
+                    - `type=MANAGER`: 운영진 모집 알림
+                    - `generation`: 알림을 받을 모집 기수 (예: 14기 모집이면 14)
+
+                    모집 공고 `openDate`가 되면 해당 기수·타입에 맞게 등록된 이메일로 알림 메일이 발송됩니다.
+                    알림 발송 후 구독 정보는 자동으로 삭제됩니다.
+
+                    같은 이메일·타입·기수 조합으로 중복 등록 시 400 에러가 반환됩니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "구독 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 등록된 이메일 (ALREADY_ENROLLED_EMAIL)"),
+    })
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public void subscribeMember(
-            @Parameter(description = "구독할 이메일 주소")
+            @Parameter(description = "알림을 받을 이메일 주소", example = "example@seoultech.ac.kr")
             @RequestParam("email") String email,
-            @Parameter(description = "구독 타입 (예: RECRUITMENT)")
-            @RequestParam("type") SubscriptionType type
+            @Parameter(description = "구독할 모집 타입 (`MEMBER`: 아기사자, `MANAGER`: 운영진)", example = "MEMBER")
+            @RequestParam("type") SubscriptionType type,
+            @Parameter(description = "알림을 받을 모집 기수", example = "14")
+            @RequestParam("generation") int generation
     ) {
-        subscriptionService.register(email, type);
+        subscriptionService.register(email, type, generation);
     }
 }

--- a/src/main/java/com/snut_likelion/domain/recruitment/entity/RecruitmentSubscription.java
+++ b/src/main/java/com/snut_likelion/domain/recruitment/entity/RecruitmentSubscription.java
@@ -27,18 +27,23 @@ public class RecruitmentSubscription {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 
+    @Column(nullable = false)
+    private int generation;
+
     @Builder
-    public RecruitmentSubscription(Long id, String email, SubscriptionType subscriptionType) {
+    public RecruitmentSubscription(Long id, String email, SubscriptionType subscriptionType, int generation) {
         this.id = id;
         this.email = email;
         this.subscriptionType = subscriptionType;
+        this.generation = generation;
         this.createdAt = LocalDateTime.now();
     }
 
-    public static RecruitmentSubscription of(String email, SubscriptionType subscriptionType) {
+    public static RecruitmentSubscription of(String email, SubscriptionType subscriptionType, int generation) {
         return RecruitmentSubscription.builder()
                 .email(email)
                 .subscriptionType(subscriptionType)
+                .generation(generation)
                 .build();
     }
 }

--- a/src/main/java/com/snut_likelion/domain/recruitment/infra/RecruitmentSubscriptionRepository.java
+++ b/src/main/java/com/snut_likelion/domain/recruitment/infra/RecruitmentSubscriptionRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface RecruitmentSubscriptionRepository extends JpaRepository<RecruitmentSubscription, Long> {
 
-    List<RecruitmentSubscription> findAllBySubscriptionType(SubscriptionType type);
+    List<RecruitmentSubscription> findAllBySubscriptionTypeAndGeneration(SubscriptionType type, int generation);
 
-    boolean existsByEmailAndSubscriptionType(String email, SubscriptionType type);
+    boolean existsByEmailAndSubscriptionTypeAndGeneration(String email, SubscriptionType type, int generation);
 }

--- a/src/main/java/com/snut_likelion/domain/recruitment/schedule/RecruitmentNotifyScheduler.java
+++ b/src/main/java/com/snut_likelion/domain/recruitment/schedule/RecruitmentNotifyScheduler.java
@@ -45,13 +45,13 @@ public class RecruitmentNotifyScheduler {
                 .collect(Collectors.toSet());
 
         for (Recruitment rec : toNotify) {
-            // 1) 타입별 구독자 조회
+            // 1) 타입·기수별 구독자 조회
             SubscriptionType subType = rec.getRecruitmentType() == RecruitmentType.MEMBER
                     ? SubscriptionType.MEMBER
                     : SubscriptionType.MANAGER;
 
             List<RecruitmentSubscription> subs = recruitmentSubscriptionRepository
-                    .findAllBySubscriptionType(subType);
+                    .findAllBySubscriptionTypeAndGeneration(subType, rec.getGeneration());
 
             // 2) 구독자 이메일 Set
             Set<String> subscriberEmails = subs.stream()

--- a/src/main/java/com/snut_likelion/domain/recruitment/service/SubscriptionService.java
+++ b/src/main/java/com/snut_likelion/domain/recruitment/service/SubscriptionService.java
@@ -16,11 +16,11 @@ public class SubscriptionService {
     private final RecruitmentSubscriptionRepository recruitmentSubscriptionRepository;
 
     @Transactional
-    public void register(String email, SubscriptionType subscriptionType) {
-        if (recruitmentSubscriptionRepository.existsByEmailAndSubscriptionType(email, subscriptionType)) {
+    public void register(String email, SubscriptionType subscriptionType, int generation) {
+        if (recruitmentSubscriptionRepository.existsByEmailAndSubscriptionTypeAndGeneration(email, subscriptionType, generation)) {
             throw new BadRequestException(RecruitmentErrorCode.ALREADY_ENROLLED_EMAIL);
         }
 
-        recruitmentSubscriptionRepository.save(RecruitmentSubscription.of(email, subscriptionType));
+        recruitmentSubscriptionRepository.save(RecruitmentSubscription.of(email, subscriptionType, generation));
     }
 }

--- a/src/test/java/com/snut_likelion/domain/recruitment/schedule/RecruitmentNotifySchedulerTest.java
+++ b/src/test/java/com/snut_likelion/domain/recruitment/schedule/RecruitmentNotifySchedulerTest.java
@@ -1,0 +1,267 @@
+package com.snut_likelion.domain.recruitment.schedule;
+
+import com.snut_likelion.admin.recruitment.service.NotificationService;
+import com.snut_likelion.domain.recruitment.entity.Recruitment;
+import com.snut_likelion.domain.recruitment.entity.RecruitmentSubscription;
+import com.snut_likelion.domain.recruitment.entity.RecruitmentType;
+import com.snut_likelion.domain.recruitment.entity.SubscriptionType;
+import com.snut_likelion.domain.recruitment.infra.RecruitmentRepository;
+import com.snut_likelion.domain.recruitment.infra.RecruitmentSubscriptionRepository;
+import com.snut_likelion.domain.user.entity.User;
+import com.snut_likelion.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RecruitmentNotifySchedulerTest {
+
+    @Mock
+    RecruitmentRepository recruitmentRepository;
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    NotificationService notificationService;
+    @Mock
+    RecruitmentSubscriptionRepository subscriptionRepository;
+
+    @InjectMocks
+    RecruitmentNotifyScheduler scheduler;
+
+    // ───────────────────────────────────────────────
+    // 기본 발송 흐름
+    // ───────────────────────────────────────────────
+
+    @Test
+    void sendNotifications_noTarget_skip() {
+        // given: 발송 대상 모집 없음
+        when(recruitmentRepository.findAllByOpenDateLessThanEqualAndStartNotifiedFalse(any()))
+                .thenReturn(List.of());
+
+        // when
+        scheduler.sendRecruitmentStartNotifications();
+
+        // then: 아무것도 호출되지 않음
+        verifyNoInteractions(notificationService, subscriptionRepository, userRepository);
+    }
+
+    @Test
+    void sendNotifications_sendsToAllUsersAndSubscribers() {
+        // given
+        Recruitment rec = recruitment(14, RecruitmentType.MEMBER);
+        User user1 = user("a@test.com");
+        User user2 = user("b@test.com");
+        RecruitmentSubscription sub = subscription("sub@test.com", SubscriptionType.MEMBER, 14);
+
+        when(recruitmentRepository.findAllByOpenDateLessThanEqualAndStartNotifiedFalse(any()))
+                .thenReturn(List.of(rec));
+        when(userRepository.findAll()).thenReturn(List.of(user1, user2));
+        when(subscriptionRepository.findAllBySubscriptionTypeAndGeneration(SubscriptionType.MEMBER, 14))
+                .thenReturn(List.of(sub));
+
+        // when
+        scheduler.sendRecruitmentStartNotifications();
+
+        // then: 유저 2명 + 구독자 1명 총 3건 발송
+        verify(notificationService, times(3)).sendRecruitmentStartNotice(any(), eq(rec));
+        verify(notificationService).sendRecruitmentStartNotice("a@test.com", rec);
+        verify(notificationService).sendRecruitmentStartNotice("b@test.com", rec);
+        verify(notificationService).sendRecruitmentStartNotice("sub@test.com", rec);
+    }
+
+    @Test
+    void sendNotifications_userEmailEqualsSubscriberEmail_noDuplicate() {
+        // given: 유저 이메일과 구독자 이메일이 동일한 경우 중복 제거
+        Recruitment rec = recruitment(14, RecruitmentType.MEMBER);
+        User user = user("same@test.com");
+        RecruitmentSubscription sub = subscription("same@test.com", SubscriptionType.MEMBER, 14);
+
+        when(recruitmentRepository.findAllByOpenDateLessThanEqualAndStartNotifiedFalse(any()))
+                .thenReturn(List.of(rec));
+        when(userRepository.findAll()).thenReturn(List.of(user));
+        when(subscriptionRepository.findAllBySubscriptionTypeAndGeneration(SubscriptionType.MEMBER, 14))
+                .thenReturn(List.of(sub));
+
+        // when
+        scheduler.sendRecruitmentStartNotifications();
+
+        // then: 중복 없이 1건만 발송
+        verify(notificationService, times(1)).sendRecruitmentStartNotice(eq("same@test.com"), eq(rec));
+    }
+
+    // ───────────────────────────────────────────────
+    // 파티션: 기수별 분리
+    // ───────────────────────────────────────────────
+
+    @Test
+    void sendNotifications_onlySameGenerationSubscribersReceiveMail() {
+        // given: 14기 모집 발생, 13기 구독자는 받으면 안 됨
+        Recruitment rec14 = recruitment(14, RecruitmentType.MEMBER);
+
+        when(recruitmentRepository.findAllByOpenDateLessThanEqualAndStartNotifiedFalse(any()))
+                .thenReturn(List.of(rec14));
+        when(userRepository.findAll()).thenReturn(List.of());
+        // 14기 구독자만 반환 (13기 구독자는 이 쿼리에서 애초에 조회되지 않음)
+        when(subscriptionRepository.findAllBySubscriptionTypeAndGeneration(SubscriptionType.MEMBER, 14))
+                .thenReturn(List.of(subscription("gen14@test.com", SubscriptionType.MEMBER, 14)));
+
+        // when
+        scheduler.sendRecruitmentStartNotifications();
+
+        // then: 14기 구독자에게만 발송
+        verify(notificationService).sendRecruitmentStartNotice("gen14@test.com", rec14);
+        verify(notificationService, never()).sendRecruitmentStartNotice(eq("gen13@test.com"), any());
+        // 13기 구독자 조회 자체가 발생하지 않았음을 확인
+        verify(subscriptionRepository, never())
+                .findAllBySubscriptionTypeAndGeneration(SubscriptionType.MEMBER, 13);
+    }
+
+    @Test
+    void sendNotifications_multipleRecruitments_eachUsesOwnGeneration() {
+        // given: 14기 MEMBER 모집과 15기 MANAGER 모집이 동시에 발생
+        Recruitment rec14Member = recruitment(14, RecruitmentType.MEMBER);
+        Recruitment rec15Manager = recruitment(15, RecruitmentType.MANAGER);
+
+        RecruitmentSubscription sub14 = subscription("m14@test.com", SubscriptionType.MEMBER, 14);
+        RecruitmentSubscription sub15 = subscription("m15@test.com", SubscriptionType.MANAGER, 15);
+
+        when(recruitmentRepository.findAllByOpenDateLessThanEqualAndStartNotifiedFalse(any()))
+                .thenReturn(List.of(rec14Member, rec15Manager));
+        when(userRepository.findAll()).thenReturn(List.of());
+        when(subscriptionRepository.findAllBySubscriptionTypeAndGeneration(SubscriptionType.MEMBER, 14))
+                .thenReturn(List.of(sub14));
+        when(subscriptionRepository.findAllBySubscriptionTypeAndGeneration(SubscriptionType.MANAGER, 15))
+                .thenReturn(List.of(sub15));
+
+        // when
+        scheduler.sendRecruitmentStartNotifications();
+
+        // then: 각 기수·타입에 맞는 구독자에게만 발송
+        verify(notificationService).sendRecruitmentStartNotice("m14@test.com", rec14Member);
+        verify(notificationService).sendRecruitmentStartNotice("m15@test.com", rec15Manager);
+        // 교차 발송 없음
+        verify(notificationService, never()).sendRecruitmentStartNotice("m14@test.com", rec15Manager);
+        verify(notificationService, never()).sendRecruitmentStartNotice("m15@test.com", rec14Member);
+    }
+
+    // ───────────────────────────────────────────────
+    // 파티션: 모집 타입별 분리
+    // ───────────────────────────────────────────────
+
+    @Test
+    void sendNotifications_memberRecruitment_queriesMemberSubscribersOnly() {
+        // given: MEMBER 모집 → MEMBER 구독자 쿼리만 수행해야 함
+        Recruitment rec = recruitment(14, RecruitmentType.MEMBER);
+
+        when(recruitmentRepository.findAllByOpenDateLessThanEqualAndStartNotifiedFalse(any()))
+                .thenReturn(List.of(rec));
+        when(userRepository.findAll()).thenReturn(List.of());
+        when(subscriptionRepository.findAllBySubscriptionTypeAndGeneration(SubscriptionType.MEMBER, 14))
+                .thenReturn(List.of());
+
+        // when
+        scheduler.sendRecruitmentStartNotifications();
+
+        // then: MEMBER 기수 구독자 쿼리 실행
+        verify(subscriptionRepository).findAllBySubscriptionTypeAndGeneration(SubscriptionType.MEMBER, 14);
+        // MANAGER 구독자 쿼리는 실행되지 않음
+        verify(subscriptionRepository, never())
+                .findAllBySubscriptionTypeAndGeneration(eq(SubscriptionType.MANAGER), anyInt());
+    }
+
+    @Test
+    void sendNotifications_managerRecruitment_queriesManagerSubscribersOnly() {
+        // given: MANAGER 모집 → MANAGER 구독자 쿼리만 수행해야 함
+        Recruitment rec = recruitment(14, RecruitmentType.MANAGER);
+
+        when(recruitmentRepository.findAllByOpenDateLessThanEqualAndStartNotifiedFalse(any()))
+                .thenReturn(List.of(rec));
+        when(userRepository.findAll()).thenReturn(List.of());
+        when(subscriptionRepository.findAllBySubscriptionTypeAndGeneration(SubscriptionType.MANAGER, 14))
+                .thenReturn(List.of());
+
+        // when
+        scheduler.sendRecruitmentStartNotifications();
+
+        // then
+        verify(subscriptionRepository).findAllBySubscriptionTypeAndGeneration(SubscriptionType.MANAGER, 14);
+        verify(subscriptionRepository, never())
+                .findAllBySubscriptionTypeAndGeneration(eq(SubscriptionType.MEMBER), anyInt());
+    }
+
+    // ───────────────────────────────────────────────
+    // 사후 처리
+    // ───────────────────────────────────────────────
+
+    @Test
+    void sendNotifications_afterSend_subscribersDeletedAndFlagSet() {
+        // given
+        Recruitment rec = recruitment(14, RecruitmentType.MEMBER);
+        RecruitmentSubscription sub = subscription("sub@test.com", SubscriptionType.MEMBER, 14);
+
+        when(recruitmentRepository.findAllByOpenDateLessThanEqualAndStartNotifiedFalse(any()))
+                .thenReturn(List.of(rec));
+        when(userRepository.findAll()).thenReturn(List.of());
+        when(subscriptionRepository.findAllBySubscriptionTypeAndGeneration(SubscriptionType.MEMBER, 14))
+                .thenReturn(List.of(sub));
+
+        // when
+        scheduler.sendRecruitmentStartNotifications();
+
+        // then: 구독 레코드 삭제
+        verify(subscriptionRepository).deleteAll(List.of(sub));
+        // startNotified 플래그 설정
+        assertThat(rec.isStartNotified()).isTrue();
+    }
+
+    @Test
+    void sendNotifications_noSubscribersNoUsers_onlyFlagSet() {
+        // given: 구독자도 유저도 없는 경우
+        Recruitment rec = recruitment(14, RecruitmentType.MEMBER);
+
+        when(recruitmentRepository.findAllByOpenDateLessThanEqualAndStartNotifiedFalse(any()))
+                .thenReturn(List.of(rec));
+        when(userRepository.findAll()).thenReturn(List.of());
+        when(subscriptionRepository.findAllBySubscriptionTypeAndGeneration(SubscriptionType.MEMBER, 14))
+                .thenReturn(List.of());
+
+        // when
+        scheduler.sendRecruitmentStartNotifications();
+
+        // then: 발송은 없고 플래그만 설정
+        verify(notificationService, never()).sendRecruitmentStartNotice(any(), any());
+        assertThat(rec.isStartNotified()).isTrue();
+    }
+
+    // ───────────────────────────────────────────────
+    // 헬퍼
+    // ───────────────────────────────────────────────
+
+    private Recruitment recruitment(int generation, RecruitmentType type) {
+        return Recruitment.builder()
+                .id((long) generation)
+                .generation(generation)
+                .recruitmentType(type)
+                .openDate(LocalDateTime.now().minusMinutes(1))
+                .closeDate(LocalDateTime.now().plusDays(7))
+                .build();
+    }
+
+    private User user(String email) {
+        return User.builder().email(email).build();
+    }
+
+    private RecruitmentSubscription subscription(String email, SubscriptionType type, int generation) {
+        return RecruitmentSubscription.of(email, type, generation);
+    }
+}

--- a/src/test/java/com/snut_likelion/domain/recruitment/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/snut_likelion/domain/recruitment/service/SubscriptionServiceTest.java
@@ -1,0 +1,150 @@
+package com.snut_likelion.domain.recruitment.service;
+
+import com.snut_likelion.domain.recruitment.entity.RecruitmentSubscription;
+import com.snut_likelion.domain.recruitment.entity.SubscriptionType;
+import com.snut_likelion.domain.recruitment.exception.RecruitmentErrorCode;
+import com.snut_likelion.domain.recruitment.infra.RecruitmentSubscriptionRepository;
+import com.snut_likelion.global.error.exception.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionServiceTest {
+
+    @Mock
+    RecruitmentSubscriptionRepository subscriptionRepository;
+
+    @InjectMocks
+    SubscriptionService subscriptionService;
+
+    // ───────────────────────────────────────────────
+    // 정상 케이스
+    // ───────────────────────────────────────────────
+
+    @Test
+    void register_success() {
+        // given
+        String email = "user@seoultech.ac.kr";
+        SubscriptionType type = SubscriptionType.MEMBER;
+        int generation = 14;
+
+        when(subscriptionRepository.existsByEmailAndSubscriptionTypeAndGeneration(email, type, generation))
+                .thenReturn(false);
+
+        // when
+        subscriptionService.register(email, type, generation);
+
+        // then
+        ArgumentCaptor<RecruitmentSubscription> captor = ArgumentCaptor.forClass(RecruitmentSubscription.class);
+        verify(subscriptionRepository).save(captor.capture());
+        RecruitmentSubscription saved = captor.getValue();
+
+        assertAll(
+                () -> assertThat(saved.getEmail()).isEqualTo(email),
+                () -> assertThat(saved.getSubscriptionType()).isEqualTo(type),
+                () -> assertThat(saved.getGeneration()).isEqualTo(generation)
+        );
+    }
+
+    @Test
+    void register_manager_success() {
+        // given
+        String email = "manager@seoultech.ac.kr";
+        SubscriptionType type = SubscriptionType.MANAGER;
+        int generation = 14;
+
+        when(subscriptionRepository.existsByEmailAndSubscriptionTypeAndGeneration(email, type, generation))
+                .thenReturn(false);
+
+        // when
+        subscriptionService.register(email, type, generation);
+
+        // then
+        ArgumentCaptor<RecruitmentSubscription> captor = ArgumentCaptor.forClass(RecruitmentSubscription.class);
+        verify(subscriptionRepository).save(captor.capture());
+        RecruitmentSubscription saved = captor.getValue();
+
+        assertAll(
+                () -> assertThat(saved.getSubscriptionType()).isEqualTo(SubscriptionType.MANAGER),
+                () -> assertThat(saved.getGeneration()).isEqualTo(14)
+        );
+    }
+
+    // ───────────────────────────────────────────────
+    // 중복 등록
+    // ───────────────────────────────────────────────
+
+    @Test
+    void register_duplicate_sameCombination_throws() {
+        // given: 동일한 이메일+타입+기수 조합 중복 등록 시도
+        String email = "user@seoultech.ac.kr";
+        SubscriptionType type = SubscriptionType.MEMBER;
+        int generation = 14;
+
+        when(subscriptionRepository.existsByEmailAndSubscriptionTypeAndGeneration(email, type, generation))
+                .thenReturn(true);
+
+        // when / then
+        assertThatThrownBy(() -> subscriptionService.register(email, type, generation))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(RecruitmentErrorCode.ALREADY_ENROLLED_EMAIL.getMessage());
+
+        verify(subscriptionRepository, never()).save(any());
+    }
+
+    // ───────────────────────────────────────────────
+    // 파티션: 기수가 다르면 동일 이메일+타입이어도 별도 등록 가능
+    // ───────────────────────────────────────────────
+
+    @Test
+    void register_sameEmailAndType_differentGeneration_success() {
+        // given: 13기에는 이미 구독했지만 14기는 새로 구독하는 경우
+        String email = "user@seoultech.ac.kr";
+        SubscriptionType type = SubscriptionType.MEMBER;
+
+        when(subscriptionRepository.existsByEmailAndSubscriptionTypeAndGeneration(email, type, 14))
+                .thenReturn(false);
+
+        // when
+        subscriptionService.register(email, type, 14);
+
+        // then: 14기 구독이 정상 저장됨
+        ArgumentCaptor<RecruitmentSubscription> captor = ArgumentCaptor.forClass(RecruitmentSubscription.class);
+        verify(subscriptionRepository).save(captor.capture());
+        assertThat(captor.getValue().getGeneration()).isEqualTo(14);
+    }
+
+    // ───────────────────────────────────────────────
+    // 파티션: 타입이 다르면 동일 이메일+기수이어도 별도 등록 가능
+    // ───────────────────────────────────────────────
+
+    @Test
+    void register_sameEmailAndGeneration_differentType_success() {
+        // given: 같은 기수지만 MEMBER와 MANAGER를 각각 구독하는 경우
+        String email = "user@seoultech.ac.kr";
+        int generation = 14;
+
+        when(subscriptionRepository.existsByEmailAndSubscriptionTypeAndGeneration(email, SubscriptionType.MANAGER, generation))
+                .thenReturn(false);
+
+        // when
+        subscriptionService.register(email, SubscriptionType.MANAGER, generation);
+
+        // then
+        ArgumentCaptor<RecruitmentSubscription> captor = ArgumentCaptor.forClass(RecruitmentSubscription.class);
+        verify(subscriptionRepository).save(captor.capture());
+        assertAll(
+                () -> assertThat(captor.getValue().getSubscriptionType()).isEqualTo(SubscriptionType.MANAGER),
+                () -> assertThat(captor.getValue().getGeneration()).isEqualTo(14)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `RecruitmentSubscription`에 `generation` 필드를 추가하여 구독 등록·중복 검증·알림 발송을 기수 단위로 분리
- 기존에는 타입(MEMBER/MANAGER)만으로 구독자를 조회해, 이전 기수 구독자가 다음 기수 모집 알림도 받는 문제가 있었음
- 구독 API(`POST /api/v1/subscriptions`)에 `generation` 파라미터 추가 및 Swagger 문서 보강

## Changes
- `RecruitmentSubscription`: `generation` 필드 추가
- `RecruitmentSubscriptionRepository`: 기수 포함 쿼리로 교체 (`findAllBySubscriptionTypeAndGeneration`,
  `existsByEmailAndSubscriptionTypeAndGeneration`)
- `RecruitmentNotifyScheduler`: 알림 발송 시 해당 기수 구독자만 조회하도록 수정
- `SubscriptionController` / `SubscriptionService`: `generation` 파라미터 수신 및 저장 처리

## Test
- `SubscriptionServiceTest`: 기수·타입 파티션별 등록 성공 / 중복 예외 검증 (5개)
- `RecruitmentNotifySchedulerTest`: 기수별 발송 격리, 타입별 구독자 쿼리 분리, 발송 후 구독 삭제 및 `startNotified`
  플래그 설정 검증 (9개)