### PR TITLE
[Fix/71-find-pw]: 비밀 번호 찾기 코드 인증 방식으로 변경

### DIFF
--- a/src/main/java/com/snut_likelion/domain/auth/service/AuthMailService.java
+++ b/src/main/java/com/snut_likelion/domain/auth/service/AuthMailService.java
@@ -35,7 +35,7 @@ public class AuthMailService {
         boolean isExists = userRepository.existsByEmail(email);
         if (!isExists) throw new NotFoundException(UserErrorCode.NOT_FOUND);
         String code = this.generateCertificationCode(email);
-        mailSender.sendChangePasswordLinkMail(email, code);
+        mailSender.sendPasswordResetCode(email, code);
     }
 
     private String generateCertificationCode(String email) {

--- a/src/main/java/com/snut_likelion/global/provider/MailSender.java
+++ b/src/main/java/com/snut_likelion/global/provider/MailSender.java
@@ -8,7 +8,7 @@ public interface MailSender {
 
     void sendVerificationCode(String toEmail, String code);
 
-    void sendChangePasswordLinkMail(String toEmail, String code);
+    void sendPasswordResetCode(String toEmail, String code);
 
     void sendInterviewScheduledMail(String toEmail, String username, String recruitmentType);
 

--- a/src/main/java/com/snut_likelion/infra/mail/GmailSender.java
+++ b/src/main/java/com/snut_likelion/infra/mail/GmailSender.java
@@ -40,12 +40,11 @@ public class GmailSender implements MailSender {
     }
 
     @Override
-    public void sendChangePasswordLinkMail(String toEmail, String code) {
-        String changePasswordUrl = clientUrl + "/auth/change-password?code=" + code;
-        String subject = "[서울과학기술대학교 멋쟁이사자처럼] 비밀번호 변경 페이지 주소";
-        String changePwdMsg = "비밀번호 변경 페이지 주소: " + changePasswordUrl;
-        mailSender.send(this.generationMessage(toEmail, subject, changePwdMsg));
-        log.info("비밀번호 변경 링크 메일 발송 성공: {}, {}", toEmail, code);
+    public void sendPasswordResetCode(String toEmail, String code) {
+        String subject = "[서울과학기술대학교 멋쟁이사자처럼] 비밀번호 재설정 인증 코드";
+        String body = "인증 코드: " + code + "\n\n이 코드는 10분간 유효합니다.";
+        mailSender.send(this.generationMessage(toEmail, subject, body));
+        log.info("비밀번호 재설정 인증 코드 메일 발송 성공: {}, {}", toEmail, code);
     }
 
     @Override

--- a/src/test/java/com/snut_likelion/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/snut_likelion/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,219 @@
+package com.snut_likelion.domain.auth.service;
+
+import com.snut_likelion.domain.auth.dto.ResetPasswordRequest;
+import com.snut_likelion.domain.auth.entity.CertificationToken;
+import com.snut_likelion.domain.auth.exception.AuthErrorCode;
+import com.snut_likelion.domain.auth.repository.CertificationTokenRepository;
+import com.snut_likelion.domain.user.entity.User;
+import com.snut_likelion.domain.user.exception.UserErrorCode;
+import com.snut_likelion.domain.user.repository.UserRepository;
+import com.snut_likelion.global.error.exception.BadRequestException;
+import com.snut_likelion.global.error.exception.NotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    CertificationTokenRepository certificationTokenRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    AuthService authService;
+
+    String email = "test@example.com";
+    String code = "ABC123";
+    User user;
+    CertificationToken validToken;
+
+    @BeforeEach
+    void setup() {
+        user = User.builder()
+                .id(1L)
+                .email(email)
+                .username("tester")
+                .build();
+
+        validToken = CertificationToken.builder()
+                .id(1L)
+                .email(email)
+                .code(code)
+                .expiredAt(LocalDateTime.now().plusMinutes(10))
+                .build();
+    }
+
+    @Test
+    void resetPassword_success() {
+        // given
+        ResetPasswordRequest req = ResetPasswordRequest.builder()
+                .email(email)
+                .code(code)
+                .newPassword("newPwd123!")
+                .newPasswordConfirm("newPwd123!")
+                .build();
+
+        when(certificationTokenRepository.findByEmail(email)).thenReturn(Optional.of(validToken));
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(passwordEncoder.encode("newPwd123!")).thenReturn("encoded_newPwd123!");
+
+        // when
+        authService.resetPassword(req);
+
+        // then
+        verify(certificationTokenRepository).delete(validToken);
+        assertThat(user.getPassword()).isEqualTo("encoded_newPwd123!");
+    }
+
+    @Test
+    void resetPassword_invalidCode_throws() {
+        // given
+        ResetPasswordRequest req = ResetPasswordRequest.builder()
+                .email(email)
+                .code("WRONG1")
+                .newPassword("newPwd123!")
+                .newPasswordConfirm("newPwd123!")
+                .build();
+
+        when(certificationTokenRepository.findByEmail(email)).thenReturn(Optional.of(validToken));
+
+        // when / then
+        assertThatThrownBy(() -> authService.resetPassword(req))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(AuthErrorCode.INVALID_CERTIFICATION_TOKEN.getMessage());
+
+        verify(userRepository, never()).findByEmail(anyString());
+    }
+
+    @Test
+    void resetPassword_expiredToken_throws() {
+        // given
+        CertificationToken expiredToken = CertificationToken.builder()
+                .id(2L)
+                .email(email)
+                .code(code)
+                .expiredAt(LocalDateTime.now().minusMinutes(1))
+                .build();
+
+        ResetPasswordRequest req = ResetPasswordRequest.builder()
+                .email(email)
+                .code(code)
+                .newPassword("newPwd123!")
+                .newPasswordConfirm("newPwd123!")
+                .build();
+
+        when(certificationTokenRepository.findByEmail(email)).thenReturn(Optional.of(expiredToken));
+
+        // when / then
+        assertThatThrownBy(() -> authService.resetPassword(req))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(AuthErrorCode.INVALID_CERTIFICATION_TOKEN.getMessage());
+
+        verify(userRepository, never()).findByEmail(anyString());
+    }
+
+    @Test
+    void resetPassword_noToken_throws() {
+        // given
+        ResetPasswordRequest req = ResetPasswordRequest.builder()
+                .email(email)
+                .code(code)
+                .newPassword("newPwd123!")
+                .newPasswordConfirm("newPwd123!")
+                .build();
+
+        when(certificationTokenRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> authService.resetPassword(req))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(AuthErrorCode.INVALID_CERTIFICATION_TOKEN.getMessage());
+    }
+
+    @Test
+    void resetPassword_userNotFound_throws() {
+        // given
+        ResetPasswordRequest req = ResetPasswordRequest.builder()
+                .email(email)
+                .code(code)
+                .newPassword("newPwd123!")
+                .newPasswordConfirm("newPwd123!")
+                .build();
+
+        when(certificationTokenRepository.findByEmail(email)).thenReturn(Optional.of(validToken));
+        when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+        // when / then
+        assertThatThrownBy(() -> authService.resetPassword(req))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(UserErrorCode.NOT_FOUND.getMessage());
+
+        verify(certificationTokenRepository).delete(validToken);
+    }
+
+    @Test
+    void certifyCode_success() {
+        // given
+        when(certificationTokenRepository.findByEmail(email)).thenReturn(Optional.of(validToken));
+
+        // when
+        authService.certifyCode(email, code);
+
+        // then
+        verify(certificationTokenRepository).delete(validToken);
+    }
+
+    @Test
+    void certifyCode_invalidCode_throws() {
+        // given
+        when(certificationTokenRepository.findByEmail(email)).thenReturn(Optional.of(validToken));
+
+        // when / then
+        assertThatThrownBy(() -> authService.certifyCode(email, "WRONG1"))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(AuthErrorCode.INVALID_CERTIFICATION_TOKEN.getMessage());
+
+        verify(certificationTokenRepository, never()).delete(any());
+    }
+
+    @Test
+    void certifyCode_expiredToken_throws() {
+        // given
+        CertificationToken expiredToken = CertificationToken.builder()
+                .id(2L)
+                .email(email)
+                .code(code)
+                .expiredAt(LocalDateTime.now().minusMinutes(1))
+                .build();
+
+        when(certificationTokenRepository.findByEmail(email)).thenReturn(Optional.of(expiredToken));
+
+        // when / then
+        assertThatThrownBy(() -> authService.certifyCode(email, code))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(AuthErrorCode.INVALID_CERTIFICATION_TOKEN.getMessage());
+
+        verify(certificationTokenRepository, never()).delete(any());
+    }
+}


### PR DESCRIPTION
## 개요

비밀번호 재설정 메일 방식을 **링크 클릭 방식**에서 **인증 코드 입력 방식**으로 변경합니다.

기존에는 이메일에 재설정 링크(`/auth/change-password?code=ABC123`)를 담아 보냈으나,
사용자가 코드를 직접 입력하는 방식으로 UX를 개선합니다.

## 변경 사항

### feat
- `MailSender` 인터페이스의 `sendChangePasswordLinkMail()` → `sendPasswordResetCode()`로 변경
- `GmailSender`에서 URL 링크 생성 제거, 인증 코드를 메일 본문에 직접 노출
    - 제목: `[서울과학기술대학교 멋쟁이사자처럼] 비밀번호 재설정 인증 코드`
    - 본문: `인증 코드: ABC123\n\n이 코드는 10분간 유효합니다.`
- `AuthMailService`에서 변경된 메서드명으로 호출부 수정

### test
- `AuthService` 단위 테스트 추가 (8개)
    - `resetPassword`: 성공, 잘못된 코드, 만료된 토큰, 토큰 없음, 유저 없음
    - `certifyCode`: 성공, 잘못된 코드, 만료된 토큰

## API 변경 없음

`PATCH /api/v1/auth/password/reset` 스펙은 동일합니다.
프론트엔드는 URL 파싱 로직을 제거하고, 사용자가 입력한 코드를 그대로 `code` 필드에 담아 요청하면 됩니다.

| 필드 | 설명 |
  |------|------|
| `email` | 사용자 이메일 |
| `code` | 메일로 받은 6자리 인증 코드 |
| `newPassword` | 새 비밀번호 |
| `newPasswordConfirm` | 새 비밀번호 확인 |