### PR TITLE
fix(#77): 프로젝트 도메인 4개 버그 수정

### DIFF
--- a/src/main/java/com/snut_likelion/admin/project/controller/AdminProjectController.java
+++ b/src/main/java/com/snut_likelion/admin/project/controller/AdminProjectController.java
@@ -1,5 +1,6 @@
 package com.snut_likelion.admin.project.controller;
 
+import com.snut_likelion.admin.project.dto.req.AdminCreateRetrospectionRequest;
 import com.snut_likelion.admin.project.dto.res.ProjectPageResponse;
 import com.snut_likelion.admin.project.service.AdminProjectService;
 import com.snut_likelion.domain.project.dto.req.CreateProjectPresignedRequest;
@@ -50,9 +51,9 @@ public class AdminProjectController {
             description = "Presigned URL로 이미지 업로드 완료 후 storedFileName을 전달하여 프로젝트를 생성합니다.")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<Object> createProject(@Valid @RequestBody CreateProjectPresignedRequest req) {
-        adminProjectService.create(req);
-        return ApiResponse.success("프로젝트 생성 성공");
+    public ApiResponse<Long> createProject(@Valid @RequestBody CreateProjectPresignedRequest req) {
+        Long projectId = adminProjectService.create(req);
+        return ApiResponse.success(projectId, "프로젝트 생성 성공");
     }
 
     @Operation(summary = "관리자 프로젝트 수정 (Presigned URL 기반)")
@@ -84,6 +85,20 @@ public class AdminProjectController {
         return ApiResponse.success(
                 adminProjectService.getAllRetrospectionsByProjectId(projectId),
                 "프로젝트 회고 목록 조회 성공"
+        );
+    }
+
+    @Operation(summary = "관리자 프로젝트 회고 생성",
+            description = "memberId를 지정하여 특정 멤버의 회고를 관리자가 직접 등록합니다.")
+    @PostMapping("/{projectId}/retrospections")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<RetrospectionResponse> createProjectRetrospection(
+            @PathVariable("projectId") Long projectId,
+            @Valid @RequestBody AdminCreateRetrospectionRequest req
+    ) {
+        return ApiResponse.success(
+                adminProjectService.createRetrospection(projectId, req),
+                "프로젝트 회고 등록 성공"
         );
     }
 

--- a/src/main/java/com/snut_likelion/admin/project/dto/req/AdminCreateRetrospectionRequest.java
+++ b/src/main/java/com/snut_likelion/admin/project/dto/req/AdminCreateRetrospectionRequest.java
@@ -1,0 +1,18 @@
+package com.snut_likelion.admin.project.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminCreateRetrospectionRequest {
+
+    @NotNull(message = "회원 ID를 입력해주세요.")
+    private Long memberId;
+
+    @NotBlank(message = "내용을 입력해주세요.")
+    private String content;
+}

--- a/src/main/java/com/snut_likelion/admin/project/service/AdminProjectService.java
+++ b/src/main/java/com/snut_likelion/admin/project/service/AdminProjectService.java
@@ -1,8 +1,10 @@
 package com.snut_likelion.admin.project.service;
 
+import com.snut_likelion.admin.project.dto.req.AdminCreateRetrospectionRequest;
 import com.snut_likelion.admin.project.dto.res.ProjectPageResponse;
 import com.snut_likelion.admin.project.infra.AdminProjectQueryRepository;
 import com.snut_likelion.domain.project.dto.req.CreateProjectPresignedRequest;
+import com.snut_likelion.domain.project.dto.req.CreateRetrospectionRequest;
 import com.snut_likelion.domain.project.dto.req.UpdateProjectPresignedRequest;
 import com.snut_likelion.domain.project.dto.res.RetrospectionResponse;
 import com.snut_likelion.domain.project.service.ProjectCommandService;
@@ -39,8 +41,8 @@ public class AdminProjectService {
     }
 
     @Transactional
-    public void create(CreateProjectPresignedRequest req) {
-        projectCommandService.createPresigned(req);
+    public Long create(CreateProjectPresignedRequest req) {
+        return projectCommandService.createPresigned(req);
     }
 
     @Transactional
@@ -56,6 +58,12 @@ public class AdminProjectService {
     @Transactional(readOnly = true)
     public List<RetrospectionResponse> getAllRetrospectionsByProjectId(Long projectId) {
         return projectRetrospectionService.getAllByProjectId(projectId);
+    }
+
+    @Transactional
+    public RetrospectionResponse createRetrospection(Long projectId, AdminCreateRetrospectionRequest req) {
+        CreateRetrospectionRequest inner = new CreateRetrospectionRequest(req.getContent());
+        return projectRetrospectionService.create(projectId, req.getMemberId(), inner);
     }
 
     @Transactional

--- a/src/main/java/com/snut_likelion/domain/project/dto/req/CreateProjectPresignedRequest.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/req/CreateProjectPresignedRequest.java
@@ -34,4 +34,10 @@ public class CreateProjectPresignedRequest {
 
     @NotEmpty(message = "프로젝트 이미지는 최소 1장 이상 필요합니다.")
     private List<@NotBlank(message = "storedFileName은 빈 값일 수 없습니다.") String> imageStoredFileNames;
+
+    private String websiteUrl;
+    private String playstoreUrl;
+    private String appstoreUrl;
+
+    private List<@NotBlank(message = "stack은 빈 값일 수 없습니다.") String> stacks;
 }

--- a/src/main/java/com/snut_likelion/domain/project/dto/req/UpdateProjectPresignedRequest.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/req/UpdateProjectPresignedRequest.java
@@ -28,6 +28,8 @@ public class UpdateProjectPresignedRequest {
 
     private List<@NotBlank(message = "storedFileName은 빈 값일 수 없습니다.") String> newImageStoredFileNames;
 
+    private List<@NotBlank(message = "stack은 빈 값일 수 없습니다.") String> stacks;
+
     @AssertTrue(message = "수정할 값이 없습니다.")
     private boolean isAnyFieldProvided() {
         return (name != null && !name.isBlank())
@@ -39,6 +41,7 @@ public class UpdateProjectPresignedRequest {
                 || (websiteUrl != null && !websiteUrl.isBlank())
                 || (playstoreUrl != null && !playstoreUrl.isBlank())
                 || (appstoreUrl != null && !appstoreUrl.isBlank())
-                || (newImageStoredFileNames != null && !newImageStoredFileNames.isEmpty());
+                || (newImageStoredFileNames != null && !newImageStoredFileNames.isEmpty())
+                || (stacks != null && !stacks.isEmpty());
     }
 }

--- a/src/main/java/com/snut_likelion/domain/project/dto/res/ProjectDetailResponse.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/res/ProjectDetailResponse.java
@@ -24,6 +24,7 @@ public class ProjectDetailResponse {
     private String playstoreUrl;
     private String appstoreUrl;
     private List<String> tags;
+    private List<String> stacks;
     private List<Participant> members;
     private String category;
     private List<String> imageUrls; // 응답은 항상 URL (key 아님)
@@ -31,8 +32,8 @@ public class ProjectDetailResponse {
     @Builder
     public ProjectDetailResponse(Long id, String name, String intro, String description,
                                  int generation, String websiteUrl, String playstoreUrl,
-                                 String appstoreUrl, List<String> tags, List<Participant> members,
-                                 ProjectCategory category, List<String> imageUrls) {
+                                 String appstoreUrl, List<String> tags, List<String> stacks,
+                                 List<Participant> members, ProjectCategory category, List<String> imageUrls) {
         this.id = id;
         this.name = name;
         this.intro = intro;
@@ -42,6 +43,7 @@ public class ProjectDetailResponse {
         this.playstoreUrl = playstoreUrl;
         this.appstoreUrl = appstoreUrl;
         this.tags = tags;
+        this.stacks = stacks;
         this.members = members;
         this.category = (category == null ? null : category.getDescription());
         this.imageUrls = imageUrls;
@@ -68,6 +70,7 @@ public class ProjectDetailResponse {
                 .appstoreUrl(project.getAppstoreUrl())
                 .category(project.getCategory())
                 .tags(project.getTagList())
+                .stacks(project.getStackList())
                 .imageUrls(imageUrls)
                 .members(project.getParticipations().stream()
                         .map(p -> p.getLionInfo().getUser())

--- a/src/main/java/com/snut_likelion/domain/project/dto/res/ProjectResponse.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/res/ProjectResponse.java
@@ -20,17 +20,19 @@ public class ProjectResponse {
     private String description;
     private int generation;
     private List<String> tags;
+    private List<String> stacks;
     private String category;
     private String thumbnailUrl; // 응답은 항상 URL (key 아님)
 
     @Builder
     public ProjectResponse(Long id, String name, String description, int generation,
-                           List<String> tags, ProjectCategory category, String thumbnailUrl) {
+                           List<String> tags, List<String> stacks, ProjectCategory category, String thumbnailUrl) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.generation = generation;
         this.tags = tags;
+        this.stacks = stacks;
         this.category = (category == null ? null : category.getDescription());
         this.thumbnailUrl = thumbnailUrl;
     }
@@ -49,6 +51,7 @@ public class ProjectResponse {
                 .description(project.getDescription())
                 .generation(project.getGeneration())
                 .tags(project.getTagList())
+                .stacks(project.getStackList())
                 .category(project.getCategory())
                 .thumbnailUrl(resolveToUrl(thumb, keyToUrl))
                 .build();

--- a/src/main/java/com/snut_likelion/domain/project/entity/Project.java
+++ b/src/main/java/com/snut_likelion/domain/project/entity/Project.java
@@ -45,6 +45,8 @@ public class Project extends BaseEntity {
 
     private String tags;
 
+    private String stacks;
+
     @Column(nullable = false, columnDefinition = "TEXT")
     private String images;
 
@@ -61,12 +63,32 @@ public class Project extends BaseEntity {
         this.category = category;
     }
 
-    public void update(String name, String intro, String description, Integer generation, ProjectCategory category) {
+    public void update(String name, String intro, String description, Integer generation, ProjectCategory category,
+                       String websiteUrl, String playstoreUrl, String appstoreUrl, List<String> stacks) {
         if (StringUtils.hasText(name)) this.name = name;
         if (StringUtils.hasText(intro)) this.intro = intro;
         if (StringUtils.hasText(description)) this.description = description;
         if (generation != null) this.generation = generation;
         if (category != null) this.category = category;
+        if (StringUtils.hasText(websiteUrl)) this.websiteUrl = websiteUrl;
+        if (StringUtils.hasText(playstoreUrl)) this.playstoreUrl = playstoreUrl;
+        if (StringUtils.hasText(appstoreUrl)) this.appstoreUrl = appstoreUrl;
+        if (stacks != null && !stacks.isEmpty()) this.setStacks(stacks);
+    }
+
+    public List<String> getStackList() {
+        if (stacks == null || stacks.isEmpty()) {
+            return List.of();
+        }
+        return List.of(stacks.split(", "));
+    }
+
+    public void setStacks(List<String> stacks) {
+        if (stacks == null || stacks.isEmpty()) {
+            this.stacks = null;
+            return;
+        }
+        this.stacks = String.join(", ", stacks).toUpperCase();
     }
 
     public String getThumbnailUrl() {

--- a/src/main/java/com/snut_likelion/domain/project/service/ProjectCommandService.java
+++ b/src/main/java/com/snut_likelion/domain/project/service/ProjectCommandService.java
@@ -47,11 +47,14 @@ public class ProjectCommandService {
                 .description(req.getDescription())
                 .category(req.getCategory())
                 .generation(req.getGeneration())
+                .websiteUrl(req.getWebsiteUrl())
+                .playstoreUrl(req.getPlaystoreUrl())
+                .appstoreUrl(req.getAppstoreUrl())
                 .build();
 
-        // FileUploadService가 검증 담당 (key 규칙 + UploadedFile 존재 확인)
         fileUploadService.validateStoredFileNames(req.getImageStoredFileNames(), UploadCategory.PROJECT);
         project.setImages(req.getImageStoredFileNames());
+        project.setStacks(req.getStacks());
 
         projectRepository.save(project);
         return project.getId();
@@ -67,7 +70,9 @@ public class ProjectCommandService {
                 .orElseThrow(() -> new NotFoundException(ProjectErrorCode.NOT_FOUND_PROJECT));
 
         project.update(req.getName(), req.getIntro(), req.getDescription(),
-                req.getGeneration(), req.getCategory());
+                req.getGeneration(), req.getCategory(),
+                req.getWebsiteUrl(), req.getPlaystoreUrl(), req.getAppstoreUrl(),
+                req.getStacks());
 
         if (req.getNewImageStoredFileNames() != null && !req.getNewImageStoredFileNames().isEmpty()) {
             fileUploadService.validateStoredFileNames(

--- a/src/test/java/com/snut_likelion/admin/project/service/AdminProjectServiceTest.java
+++ b/src/test/java/com/snut_likelion/admin/project/service/AdminProjectServiceTest.java
@@ -1,17 +1,23 @@
 package com.snut_likelion.admin.project.service;
 
+import com.snut_likelion.admin.project.dto.req.AdminCreateRetrospectionRequest;
 import com.snut_likelion.admin.project.dto.res.ProjectPageResponse;
 import com.snut_likelion.admin.project.infra.AdminProjectQueryRepository;
+import com.snut_likelion.domain.project.dto.req.CreateProjectPresignedRequest;
+import com.snut_likelion.domain.project.dto.req.CreateRetrospectionRequest;
+import com.snut_likelion.domain.project.dto.res.RetrospectionResponse;
 import com.snut_likelion.domain.project.service.ProjectCommandService;
 import com.snut_likelion.domain.project.service.ProjectRetrospectionService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
@@ -19,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,23 +33,63 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class AdminProjectServiceTest {
 
-    @Mock
-    AdminProjectQueryRepository queryRepository;
-
-    @Mock
-    ProjectCommandService projectCommandService;
-
-    @Mock
-    ProjectRetrospectionService projectRetrospectionService;
+    @Mock AdminProjectQueryRepository queryRepository;
+    @Mock ProjectCommandService projectCommandService;
+    @Mock ProjectRetrospectionService projectRetrospectionService;
 
     @InjectMocks
     AdminProjectService adminProjectService;
 
+    // ── create ───────────────────────────────────────────────────────────────
+
     @Test
     void create_delegatesToProjectCommandService() {
-        adminProjectService.create(null);
-        verify(projectCommandService).createPresigned(null);
+        CreateProjectPresignedRequest req = mock(CreateProjectPresignedRequest.class);
+        adminProjectService.create(req);
+        verify(projectCommandService).createPresigned(req);
     }
+
+    @Test
+    void create_returnsProjectIdFromCommandService() {
+        // Given
+        CreateProjectPresignedRequest req = mock(CreateProjectPresignedRequest.class);
+        when(projectCommandService.createPresigned(req)).thenReturn(42L);
+
+        // When
+        Long projectId = adminProjectService.create(req);
+
+        // Then
+        assertThat(projectId).isEqualTo(42L);
+    }
+
+    // ── createRetrospection ──────────────────────────────────────────────────
+
+    @Test
+    void createRetrospection_delegatesWithCorrectMemberIdAndContent() {
+        // Given
+        Long projectId = 1L;
+        Long memberId = 10L;
+
+        AdminCreateRetrospectionRequest req = mock(AdminCreateRetrospectionRequest.class);
+        when(req.getMemberId()).thenReturn(memberId);
+        when(req.getContent()).thenReturn("관리자가 대신 등록한 회고");
+
+        RetrospectionResponse mockResponse = mock(RetrospectionResponse.class);
+        ArgumentCaptor<CreateRetrospectionRequest> innerCaptor =
+                ArgumentCaptor.forClass(CreateRetrospectionRequest.class);
+        when(projectRetrospectionService.create(eq(projectId), eq(memberId), innerCaptor.capture()))
+                .thenReturn(mockResponse);
+
+        // When
+        RetrospectionResponse result = adminProjectService.createRetrospection(projectId, req);
+
+        // Then
+        assertThat(result).isEqualTo(mockResponse);
+        assertThat(innerCaptor.getValue().getContent()).isEqualTo("관리자가 대신 등록한 회고");
+        verify(projectRetrospectionService).create(eq(projectId), eq(memberId), any(CreateRetrospectionRequest.class));
+    }
+
+    // ── 기존 테스트 ─────────────────────────────────────────────────────────
 
     @Test
     void modify_delegatesToProjectCommandService() {

--- a/src/test/java/com/snut_likelion/domain/project/service/ProjectCommandServiceTest.java
+++ b/src/test/java/com/snut_likelion/domain/project/service/ProjectCommandServiceTest.java
@@ -16,6 +16,7 @@ import com.snut_likelion.global.error.exception.NotFoundException;
 import com.snut_likelion.infra.file.FileErrorCode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -65,6 +66,36 @@ class ProjectCommandServiceTest {
         // Then
         verify(fileUploadService).validateStoredFileNames(List.of("images/projects/uuid-img.png"), UploadCategory.PROJECT);
         verify(projectRepository).save(any(Project.class));
+    }
+
+    @Test
+    void createPresigned_withUrlAndStacks_setsFieldsOnSavedProject() {
+        // Given
+        CreateProjectPresignedRequest req = mock(CreateProjectPresignedRequest.class);
+        when(req.getName()).thenReturn("App");
+        when(req.getIntro()).thenReturn("소개");
+        when(req.getDescription()).thenReturn("설명");
+        when(req.getCategory()).thenReturn(ProjectCategory.HACKATHON);
+        when(req.getGeneration()).thenReturn(14);
+        when(req.getImageStoredFileNames()).thenReturn(List.of("images/projects/img.png"));
+        when(req.getWebsiteUrl()).thenReturn("https://example.com");
+        when(req.getPlaystoreUrl()).thenReturn("https://play.google.com/store/apps");
+        when(req.getAppstoreUrl()).thenReturn("https://apps.apple.com/app");
+        when(req.getStacks()).thenReturn(List.of("React", "Spring"));
+
+        doNothing().when(fileUploadService).validateStoredFileNames(any(), eq(UploadCategory.PROJECT));
+        ArgumentCaptor<Project> captor = ArgumentCaptor.forClass(Project.class);
+        when(projectRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        // When
+        projectCommandService.createPresigned(req);
+
+        // Then
+        Project saved = captor.getValue();
+        assertThat(saved.getWebsiteUrl()).isEqualTo("https://example.com");
+        assertThat(saved.getPlaystoreUrl()).isEqualTo("https://play.google.com/store/apps");
+        assertThat(saved.getAppstoreUrl()).isEqualTo("https://apps.apple.com/app");
+        assertThat(saved.getStackList()).containsExactly("REACT", "SPRING");
     }
 
     // ── modifyPresigned ──────────────────────────────────────────────────────
@@ -137,6 +168,37 @@ class ProjectCommandServiceTest {
         // Then
         verify(fileUploadService).validateStoredFileNames(newKeys, UploadCategory.PROJECT);
         assertThat(project.getImageUrlList()).contains("images/projects/new1.png", "images/projects/new2.png");
+    }
+
+    @Test
+    void modifyPresigned_withStacksAndUrls_updatesProject() {
+        // Given
+        Long projectId = 1L;
+        Project project = Project.builder()
+                .id(projectId).name("Old").intro("Old").description("Old")
+                .generation(12).category(ProjectCategory.HACKATHON).build();
+        project.setImages(List.of("images/projects/old.png"));
+
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(project));
+
+        UpdateProjectPresignedRequest req = mock(UpdateProjectPresignedRequest.class);
+        when(req.getName()).thenReturn(null);
+        when(req.getIntro()).thenReturn(null);
+        when(req.getDescription()).thenReturn(null);
+        when(req.getGeneration()).thenReturn(null);
+        when(req.getCategory()).thenReturn(null);
+        when(req.getWebsiteUrl()).thenReturn("https://website.com");
+        when(req.getPlaystoreUrl()).thenReturn(null);
+        when(req.getAppstoreUrl()).thenReturn(null);
+        when(req.getStacks()).thenReturn(List.of("Vue", "Django"));
+        when(req.getNewImageStoredFileNames()).thenReturn(null);
+
+        // When
+        projectCommandService.modifyPresigned(projectId, req);
+
+        // Then
+        assertThat(project.getWebsiteUrl()).isEqualTo("https://website.com");
+        assertThat(project.getStackList()).containsExactly("VUE", "DJANGO");
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
Closes #77

---

## 변경 요약 (4개 버그 수정)

### Fix 1 & 2 — 프로젝트 생성/수정 요청·응답 필드 추가

**[POST] /api/v1/projects** 및 **[POST] /api/v1/admin/projects** 요청 body에 필드 추가

```json
{
  "name": "멋사 웹 서비스",
  "intro": "한 줄 소개",
  "description": "상세 설명",
  "generation": 14,
  "category": "LONG_TERM_PROJECT",
  "imageStoredFileNames": ["project/uuid-image.jpg"],

  // 🆕 아래 4개 필드 추가 (모두 optional)
  "websiteUrl": "https://example.com",
  "playstoreUrl": "https://play.google.com/...",
  "appstoreUrl": "https://apps.apple.com/...",
  "stacks": ["REACT", "SPRING"]
}
```

**[PATCH] /api/v1/projects/{id}** 수정 요청에도 `stacks` 추가 (optional)

**조회 응답에 `stacks` 필드 추가** (목록·상세 공통)

```json
// GET /api/v1/projects/{id} 응답
{
  "code": "OK",
  "data": {
    "id": 1,
    "name": "멋사 웹 서비스",
    "tags": ["AWARD"],
    "stacks": ["REACT", "SPRING"],  // 🆕
    "imageUrls": ["https://..."],
    ...
  }
}
```

---

### Fix 3 — 관리자 회고 등록 엔드포인트 신규 추가

> 기존 일반 사용자 엔드포인트는 항상 로그인한 본인 회고로 저장됨.
> 관리자가 특정 멤버의 회고를 대신 등록할 수 있도록 신규 추가.

**[POST] /api/v1/admin/projects/{projectId}/retrospections**

```json
// 요청
{
  "memberId": 42,
  "content": "이번 프로젝트에서 많이 배웠습니다."
}

// 응답 201
{
  "code": "OK",
  "data": {
    "id": 10,
    "content": "이번 프로젝트에서 많이 배웠습니다.",
    "writer": {
      "id": 42,
      "name": "홍길동",
      "part": "FRONTEND"
    }
  },
  "message": "프로젝트 회고 등록 성공"
}
```

---

### Fix 4 — 관리자 프로젝트 생성 응답에 projectId 추가

**[POST] /api/v1/admin/projects** 응답 변경

```json
// 기존
{ "code": "OK", "message": "프로젝트 생성 성공" }

// 변경 후
{ "code": "OK", "data": 42, "message": "프로젝트 생성 성공" }
//                    ^^^ projectId
```