### PR TITLE
[codex] trigger redeploy pipeline

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# GCP GCE 배포 설정 v2
+# GCP GCE 배포 설정 v2 (임시 재배포 트리거)
 services:
   app:
     image: kimgt2828/likelion-app:latest


### PR DESCRIPTION
## What changed
- Updated a single deployment comment in `docker-compose.yml`
- This is a no-op change intended to trigger the deploy pipeline again

## Why
- We want a clean PR/merge cycle so that `dev -> main` can re-run CD
- No runtime behavior is changed by this diff

## Impact
- No application logic changes
- No infrastructure behavior changes
- Safe redeploy trigger only

## Validation
- Confirmed the diff only changes one comment line
- No tests run because the change is comment-only
