### PR TITLE
 release: project DTO Swagger 문서화 dev → main 배포

### DIFF
--- a/src/main/java/com/snut_likelion/admin/project/dto/req/AdminCreateRetrospectionRequest.java
+++ b/src/main/java/com/snut_likelion/admin/project/dto/req/AdminCreateRetrospectionRequest.java
@@ -1,5 +1,6 @@
 package com.snut_likelion.admin.project.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -8,11 +9,14 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "관리자 프로젝트 회고 등록 요청 (특정 멤버의 회고를 대신 등록)")
 public class AdminCreateRetrospectionRequest {
 
+    @Schema(description = "회고를 등록할 회원 ID", example = "42")
     @NotNull(message = "회원 ID를 입력해주세요.")
     private Long memberId;
 
+    @Schema(description = "회고 내용", example = "이번 프로젝트에서 협업과 배포 자동화를 많이 배웠습니다.")
     @NotBlank(message = "내용을 입력해주세요.")
     private String content;
 }

--- a/src/main/java/com/snut_likelion/admin/project/dto/res/ProjectPageResponse.java
+++ b/src/main/java/com/snut_likelion/admin/project/dto/res/ProjectPageResponse.java
@@ -1,6 +1,7 @@
 package com.snut_likelion.admin.project.dto.res;
 
 import com.snut_likelion.domain.project.entity.ProjectCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,12 +13,22 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "관리자 프로젝트 목록 페이지 응답")
 public class ProjectPageResponse {
 
+    @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
     private int page;
+
+    @Schema(description = "페이지 크기", example = "10")
     private int size;
+
+    @Schema(description = "전체 항목 수", example = "42")
     private long totalElements;
+
+    @Schema(description = "전체 페이지 수", example = "5")
     private int totalPages;
+
+    @Schema(description = "프로젝트 목록")
     private List<ProjectListResponse> content;
 
     @Builder
@@ -41,12 +52,22 @@ public class ProjectPageResponse {
 
     @Getter
     @NoArgsConstructor
+    @Schema(description = "관리자 프로젝트 목록 항목")
     public static class ProjectListResponse {
 
+        @Schema(description = "프로젝트 ID", example = "1")
         private Long id;
+
+        @Schema(description = "프로젝트 이름", example = "멋사 웹 서비스")
         private String name;
+
+        @Schema(description = "프로젝트 기수", example = "14")
         private int generation;
+
+        @Schema(description = "프로젝트 카테고리 (한글 설명)", example = "장기 프로젝트")
         private String category;
+
+        @Schema(description = "생성 일시", example = "2026-06-02T16:19:33")
         private LocalDateTime createAt;
 
         @Builder

--- a/src/main/java/com/snut_likelion/domain/project/dto/req/CreateProjectPresignedRequest.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/req/CreateProjectPresignedRequest.java
@@ -1,6 +1,7 @@
 package com.snut_likelion.domain.project.dto.req;
 
 import com.snut_likelion.domain.project.entity.ProjectCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -14,30 +15,45 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@Schema(description = "프로젝트 생성 요청 (Presigned URL 기반)")
 public class CreateProjectPresignedRequest {
 
+    @Schema(description = "프로젝트 이름", example = "멋사 웹 서비스")
     @NotBlank(message = "프로젝트 이름을 입력해주세요.")
     private String name;
 
+    @Schema(description = "프로젝트 한 줄 소개", example = "멋쟁이사자처럼 공식 웹 서비스")
     @NotBlank(message = "프로젝트 한 줄 소개를 입력해주세요.")
     private String intro;
 
+    @Schema(description = "프로젝트 상세 설명", example = "Spring Boot와 React로 구현한 멋사 통합 관리 시스템입니다.")
     @NotBlank(message = "프로젝트 설명을 입력해주세요.")
     private String description;
 
+    @Schema(description = "프로젝트 기수", example = "14")
     @NotNull(message = "프로젝트 기수를 입력해주세요.")
     @Positive(message = "프로젝트 기수는 1 이상이어야 합니다.")
     private Integer generation;
 
+    @Schema(description = "프로젝트 카테고리", example = "LONG_TERM_PROJECT",
+            allowableValues = {"IDEATHON", "HACKATHON", "DEMO_DAY", "LONG_TERM_PROJECT"})
     @NotNull(message = "프로젝트 카테고리를 선택해주세요.")
     private ProjectCategory category;
 
+    @Schema(description = "프로젝트 이미지 storedFileName(S3 key) 목록 (최소 1장)",
+            example = "[\"project/uuid-image.jpg\"]")
     @NotEmpty(message = "프로젝트 이미지는 최소 1장 이상 필요합니다.")
     private List<@NotBlank(message = "storedFileName은 빈 값일 수 없습니다.") String> imageStoredFileNames;
 
+    @Schema(description = "웹사이트 URL (선택)", example = "https://example.com", nullable = true)
     private String websiteUrl;
+
+    @Schema(description = "Play 스토어 URL (선택)", example = "https://play.google.com/store/apps/details?id=com.example", nullable = true)
     private String playstoreUrl;
+
+    @Schema(description = "App 스토어 URL (선택)", example = "https://apps.apple.com/app/id000000000", nullable = true)
     private String appstoreUrl;
 
+    @Schema(description = "기술 스택 목록 (선택)", example = "[\"REACT\", \"SPRING\"]", nullable = true)
     private List<@NotBlank(message = "stack은 빈 값일 수 없습니다.") String> stacks;
 }

--- a/src/main/java/com/snut_likelion/domain/project/dto/req/CreateRetrospectionRequest.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/req/CreateRetrospectionRequest.java
@@ -1,5 +1,6 @@
 package com.snut_likelion.domain.project.dto.req;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -7,8 +8,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "프로젝트 회고 작성 요청")
 public class CreateRetrospectionRequest {
 
+    @Schema(description = "회고 내용", example = "이번 프로젝트에서 협업과 배포 자동화를 많이 배웠습니다.")
     @NotEmpty(message = "내용을 입력해주세요.")
     private String content;
 

--- a/src/main/java/com/snut_likelion/domain/project/dto/req/UpdateProjectPresignedRequest.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/req/UpdateProjectPresignedRequest.java
@@ -1,6 +1,7 @@
 package com.snut_likelion.domain.project.dto.req;
 
 import com.snut_likelion.domain.project.entity.ProjectCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -12,22 +13,41 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@Schema(description = "프로젝트 수정 요청 (Presigned URL 기반, 모든 필드 선택 / 최소 1개 필수)")
 public class UpdateProjectPresignedRequest {
 
+    @Schema(description = "프로젝트 이름", example = "멋사 웹 서비스", nullable = true)
     private String name;
+
+    @Schema(description = "프로젝트 한 줄 소개", example = "멋쟁이사자처럼 공식 웹 서비스", nullable = true)
     private String intro;
+
+    @Schema(description = "프로젝트 상세 설명", example = "Spring Boot와 React로 구현한 멋사 통합 관리 시스템입니다.", nullable = true)
     private String description;
+
+    @Schema(description = "프로젝트 기수", example = "14", nullable = true)
     private Integer generation;
 
+    @Schema(description = "태그 목록", example = "[\"AWARD\"]", nullable = true)
     private List<@NotBlank(message = "tag는 빈 값일 수 없습니다.") String> tags;
 
+    @Schema(description = "프로젝트 카테고리", example = "LONG_TERM_PROJECT",
+            allowableValues = {"IDEATHON", "HACKATHON", "DEMO_DAY", "LONG_TERM_PROJECT"}, nullable = true)
     private ProjectCategory category;
+
+    @Schema(description = "웹사이트 URL", example = "https://example.com", nullable = true)
     private String websiteUrl;
+
+    @Schema(description = "Play 스토어 URL", example = "https://play.google.com/store/apps/details?id=com.example", nullable = true)
     private String playstoreUrl;
+
+    @Schema(description = "App 스토어 URL", example = "https://apps.apple.com/app/id000000000", nullable = true)
     private String appstoreUrl;
 
+    @Schema(description = "추가할 이미지 storedFileName(S3 key) 목록", example = "[\"project/uuid-image.jpg\"]", nullable = true)
     private List<@NotBlank(message = "storedFileName은 빈 값일 수 없습니다.") String> newImageStoredFileNames;
 
+    @Schema(description = "기술 스택 목록", example = "[\"REACT\", \"SPRING\"]", nullable = true)
     private List<@NotBlank(message = "stack은 빈 값일 수 없습니다.") String> stacks;
 
     @AssertTrue(message = "수정할 값이 없습니다.")

--- a/src/main/java/com/snut_likelion/domain/project/dto/res/ProjectDetailResponse.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/res/ProjectDetailResponse.java
@@ -3,6 +3,7 @@ package com.snut_likelion.domain.project.dto.res;
 import com.snut_likelion.domain.project.entity.Project;
 import com.snut_likelion.domain.project.entity.ProjectCategory;
 import com.snut_likelion.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,20 +14,46 @@ import java.util.function.Function;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "프로젝트 상세 응답")
 public class ProjectDetailResponse {
 
+    @Schema(description = "프로젝트 ID", example = "1")
     private Long id;
+
+    @Schema(description = "프로젝트 이름", example = "멋사 웹 서비스")
     private String name;
+
+    @Schema(description = "프로젝트 한 줄 소개", example = "멋쟁이사자처럼 공식 웹 서비스")
     private String intro;
+
+    @Schema(description = "프로젝트 상세 설명", example = "Spring Boot와 React로 구현한 멋사 통합 관리 시스템입니다.")
     private String description;
+
+    @Schema(description = "프로젝트 기수", example = "14")
     private int generation;
+
+    @Schema(description = "웹사이트 URL", example = "https://example.com", nullable = true)
     private String websiteUrl;
+
+    @Schema(description = "Play 스토어 URL", example = "https://play.google.com/store/apps/details?id=com.example", nullable = true)
     private String playstoreUrl;
+
+    @Schema(description = "App 스토어 URL", example = "https://apps.apple.com/app/id000000000", nullable = true)
     private String appstoreUrl;
+
+    @Schema(description = "태그 목록", example = "[\"AWARD\"]")
     private List<String> tags;
+
+    @Schema(description = "기술 스택 목록", example = "[\"REACT\", \"SPRING\"]")
     private List<String> stacks;
+
+    @Schema(description = "참여 멤버 목록")
     private List<Participant> members;
+
+    @Schema(description = "프로젝트 카테고리 (한글 설명)", example = "장기 프로젝트")
     private String category;
+
+    @Schema(description = "프로젝트 이미지 URL 목록", example = "[\"https://bucket.s3.ap-northeast-2.amazonaws.com/project/uuid-image.jpg\"]")
     private List<String> imageUrls; // 응답은 항상 URL (key 아님)
 
     @Builder
@@ -87,8 +114,13 @@ public class ProjectDetailResponse {
     }
 
     @Getter
+    @Schema(description = "프로젝트 참여 멤버")
     public static class Participant {
+
+        @Schema(description = "회원 ID", example = "42")
         private Long id;
+
+        @Schema(description = "회원 이름", example = "홍길동")
         private String username;
 
         @Builder

--- a/src/main/java/com/snut_likelion/domain/project/dto/res/ProjectResponse.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/res/ProjectResponse.java
@@ -2,6 +2,7 @@ package com.snut_likelion.domain.project.dto.res;
 
 import com.snut_likelion.domain.project.entity.Project;
 import com.snut_likelion.domain.project.entity.ProjectCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,15 +14,31 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@Schema(description = "프로젝트 목록 응답")
 public class ProjectResponse {
 
+    @Schema(description = "프로젝트 ID", example = "1")
     private Long id;
+
+    @Schema(description = "프로젝트 이름", example = "멋사 웹 서비스")
     private String name;
+
+    @Schema(description = "프로젝트 상세 설명", example = "Spring Boot와 React로 구현한 멋사 통합 관리 시스템입니다.")
     private String description;
+
+    @Schema(description = "프로젝트 기수", example = "14")
     private int generation;
+
+    @Schema(description = "태그 목록", example = "[\"AWARD\"]")
     private List<String> tags;
+
+    @Schema(description = "기술 스택 목록", example = "[\"REACT\", \"SPRING\"]")
     private List<String> stacks;
+
+    @Schema(description = "프로젝트 카테고리 (한글 설명)", example = "장기 프로젝트")
     private String category;
+
+    @Schema(description = "대표 이미지 URL", example = "https://bucket.s3.ap-northeast-2.amazonaws.com/project/uuid-image.jpg")
     private String thumbnailUrl; // 응답은 항상 URL (key 아님)
 
     @Builder

--- a/src/main/java/com/snut_likelion/domain/project/dto/res/RetrospectionResponse.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/res/RetrospectionResponse.java
@@ -6,6 +6,7 @@ import com.snut_likelion.domain.user.entity.Part;
 import com.snut_likelion.domain.user.entity.User;
 import com.snut_likelion.domain.user.exception.UserErrorCode;
 import com.snut_likelion.global.error.exception.NotFoundException;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,10 +14,16 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "프로젝트 회고 응답")
 public class RetrospectionResponse {
 
+    @Schema(description = "회고 ID", example = "10")
     private Long id;
+
+    @Schema(description = "회고 내용", example = "이번 프로젝트에서 협업과 배포 자동화를 많이 배웠습니다.")
     private String content;
+
+    @Schema(description = "작성자 정보")
     private Writer writer;
 
     @Builder
@@ -35,9 +42,16 @@ public class RetrospectionResponse {
     }
 
     @Getter
+    @Schema(description = "회고 작성자")
     public static class Writer {
+
+        @Schema(description = "작성자 회원 ID", example = "42")
         private Long id;
+
+        @Schema(description = "작성자 이름", example = "홍길동")
         private String name;
+
+        @Schema(description = "작성자 파트", example = "FRONTEND")
         private String part;
 
         @Builder


### PR DESCRIPTION
dev에 반영된 **project 도메인 DTO Swagger 문서화(@Schema)** 변경을 main(운영)에 배포합니다.
API 계약 변경 없이 Swagger UI의 필드 설명만 보강된 문서 전용 릴리스입니다.

## 작업 내용
- [x] project 도메인 DTO 8개에 `@Schema` 클래스/필드 설명 추가 (#82)
  - 요청: `CreateProjectPresignedRequest`, `UpdateProjectPresignedRequest`, `CreateRetrospectionRequest`, `AdminCreateRetrospectionRequest`
  - 응답: `ProjectResponse`, `ProjectDetailResponse`, `RetrospectionResponse`, `ProjectPageResponse` (내부 클래스 포함)

## 변경 유형
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 테스트
- [x] 문서

## 테스트
- [ ] 단위 테스트 작성/  변경)_