### PR TITLE
feat(project): 일반 회고 작성 시 memberId 지정 지원 (isMe 인가)

### DIFF
--- a/src/main/java/com/snut_likelion/domain/project/controller/ProjectRetrospectionController.java
+++ b/src/main/java/com/snut_likelion/domain/project/controller/ProjectRetrospectionController.java
@@ -25,9 +25,11 @@ public class ProjectRetrospectionController {
 
     private final ProjectRetrospectionService projectRetrospectionService;
 
-    @Operation(summary = "프로젝트 회고 작성", description = "특정 프로젝트에 회고를 작성합니다. 회고 작성 시 프로젝트 참여자로 자동 등록됩니다.")
+    @Operation(summary = "프로젝트 회고 작성",
+            description = "특정 프로젝트에 회고를 작성합니다. 회고 작성 시 프로젝트 참여자로 자동 등록됩니다. " +
+                    "일반 사용자는 본인(memberId=본인) 회고만 작성할 수 있으며, 매니저는 타 멤버의 회고도 등록할 수 있습니다.")
     @PostMapping
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_USER') and @authChecker.isMe(#loginUser.userInfo, #request.memberId)")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<RetrospectionResponse> createRetrospection(
             @Parameter(hidden = true) @AuthenticationPrincipal SnutLikeLionUser loginUser,

--- a/src/main/java/com/snut_likelion/domain/project/controller/ProjectRetrospectionController.java
+++ b/src/main/java/com/snut_likelion/domain/project/controller/ProjectRetrospectionController.java
@@ -35,7 +35,7 @@ public class ProjectRetrospectionController {
             @Valid @RequestBody CreateRetrospectionRequest request
     ) {
         return ApiResponse.success(
-                projectRetrospectionService.create(projectId, loginUser.getId(), request),
+                projectRetrospectionService.create(projectId, request.getMemberId(), request),
                 "프로젝트 회고 작성 성공"
         );
     }

--- a/src/main/java/com/snut_likelion/domain/project/dto/req/CreateRetrospectionRequest.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/req/CreateRetrospectionRequest.java
@@ -11,6 +11,9 @@ import lombok.NoArgsConstructor;
 @Schema(description = "프로젝트 회고 작성 요청")
 public class CreateRetrospectionRequest {
 
+    @Schema(description = "회고 작성 대상 회원 ID (일반 사용자는 본인만, 매니저는 타 멤버 지정 가능)", example = "42")
+    private Long memberId;
+
     @Schema(description = "회고 내용", example = "이번 프로젝트에서 협업과 배포 자동화를 많이 배웠습니다.")
     @NotEmpty(message = "내용을 입력해주세요.")
     private String content;

--- a/src/main/java/com/snut_likelion/domain/project/dto/req/CreateRetrospectionRequest.java
+++ b/src/main/java/com/snut_likelion/domain/project/dto/req/CreateRetrospectionRequest.java
@@ -2,6 +2,7 @@ package com.snut_likelion.domain.project.dto.req;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 public class CreateRetrospectionRequest {
 
     @Schema(description = "회고 작성 대상 회원 ID (일반 사용자는 본인만, 매니저는 타 멤버 지정 가능)", example = "42")
+    @NotNull(message = "회원 ID를 입력해주세요.")
     private Long memberId;
 
     @Schema(description = "회고 내용", example = "이번 프로젝트에서 협업과 배포 자동화를 많이 배웠습니다.")

--- a/src/test/java/com/snut_likelion/domain/project/controller/ProjectRetrospectionControllerTest.java
+++ b/src/test/java/com/snut_likelion/domain/project/controller/ProjectRetrospectionControllerTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -104,5 +105,37 @@ class ProjectRetrospectionControllerTest {
                 .andExpect(status().isCreated());
 
         verify(projectRetrospectionService).create(eq(PROJECT_ID), eq(42L), any());
+    }
+
+    // ── 인가(isMe 가드) ──────────────────────────────────────────────────
+
+    @Test
+    void createRetrospection_userWithOtherMemberId_forbidden() throws Exception {
+        // Given — 일반 사용자(id=5)가 타인(id=42)의 회고를 작성하려 함
+
+        // When & Then — isMe 가드로 차단되어 403, 서비스는 호출되지 않아야 한다
+        mockMvc.perform(post("/api/v1/projects/{projectId}/retrospections", PROJECT_ID)
+                        .with(login(5L, "ROLE_USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(42L, "타인 명의 회고")))
+                .andExpect(status().isForbidden());
+
+        verify(projectRetrospectionService, never()).create(anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void createRetrospection_userWithOwnMemberId_created() throws Exception {
+        // Given — 일반 사용자(id=5)가 본인(id=5)의 회고를 작성
+        when(projectRetrospectionService.create(anyLong(), anyLong(), any()))
+                .thenReturn(RetrospectionResponse.builder().id(1L).content("내용").build());
+
+        // When & Then — 본인 memberId이면 isMe 통과 → 201
+        mockMvc.perform(post("/api/v1/projects/{projectId}/retrospections", PROJECT_ID)
+                        .with(login(5L, "ROLE_USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(5L, "본인 회고")))
+                .andExpect(status().isCreated());
+
+        verify(projectRetrospectionService).create(eq(PROJECT_ID), eq(5L), any());
     }
 }

--- a/src/test/java/com/snut_likelion/domain/project/controller/ProjectRetrospectionControllerTest.java
+++ b/src/test/java/com/snut_likelion/domain/project/controller/ProjectRetrospectionControllerTest.java
@@ -89,6 +89,12 @@ class ProjectRetrospectionControllerTest {
         return objectMapper.writeValueAsString(map);
     }
 
+    private String bodyContentOnly(String content) throws Exception {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("content", content);
+        return objectMapper.writeValueAsString(map);
+    }
+
     // ── 위임(delegation) ────────────────────────────────────────────────
 
     @Test
@@ -137,5 +143,35 @@ class ProjectRetrospectionControllerTest {
                 .andExpect(status().isCreated());
 
         verify(projectRetrospectionService).create(eq(PROJECT_ID), eq(5L), any());
+    }
+
+    // ── 입력 검증(validation) ─────────────────────────────────────────────
+
+    @Test
+    void createRetrospection_missingMemberId_badRequest() throws Exception {
+        // Given — memberId 없이 요청 (가드와 분리해 검증만 보기 위해 매니저 주체 사용)
+
+        // When & Then — @NotNull 위반으로 400, 서비스는 호출되지 않아야 한다
+        mockMvc.perform(post("/api/v1/projects/{projectId}/retrospections", PROJECT_ID)
+                        .with(login(99L, "ROLE_MANAGER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(bodyContentOnly("memberId 누락 회고")))
+                .andExpect(status().isBadRequest());
+
+        verify(projectRetrospectionService, never()).create(anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void createRetrospection_blankContent_badRequest() throws Exception {
+        // Given — content 공백 (@NotEmpty 위반)
+
+        // When & Then — 400, 서비스 미호출
+        mockMvc.perform(post("/api/v1/projects/{projectId}/retrospections", PROJECT_ID)
+                        .with(login(5L, "ROLE_USER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(5L, "")))
+                .andExpect(status().isBadRequest());
+
+        verify(projectRetrospectionService, never()).create(anyLong(), anyLong(), any());
     }
 }

--- a/src/test/java/com/snut_likelion/domain/project/controller/ProjectRetrospectionControllerTest.java
+++ b/src/test/java/com/snut_likelion/domain/project/controller/ProjectRetrospectionControllerTest.java
@@ -1,0 +1,108 @@
+package com.snut_likelion.domain.project.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snut_likelion.domain.blog.repository.BlogPostRepository;
+import com.snut_likelion.domain.project.dto.res.RetrospectionResponse;
+import com.snut_likelion.domain.project.infra.ProjectRepository;
+import com.snut_likelion.domain.project.service.ProjectRetrospectionService;
+import com.snut_likelion.domain.recruitment.infra.ApplicationRepository;
+import com.snut_likelion.domain.user.repository.LionInfoRepository;
+import com.snut_likelion.global.auth.checker.AuthChecker;
+import com.snut_likelion.global.auth.jwt.JwtService;
+import com.snut_likelion.global.auth.model.SnutLikeLionUser;
+import com.snut_likelion.global.auth.model.UserInfo;
+import com.snut_likelion.global.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProjectRetrospectionController.class)
+@Import({SecurityConfig.class, AuthChecker.class})
+class ProjectRetrospectionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ProjectRetrospectionService projectRetrospectionService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @MockBean
+    private AuthenticationProvider authenticationProvider;
+
+    // AuthChecker(@Import)는 실제 빈을 사용한다. isMe는 순수 로직이지만
+    // 생성자 의존 레포는 컨텍스트 구성을 위해 목으로 채운다.
+    @MockBean
+    private LionInfoRepository lionInfoRepository;
+
+    @MockBean
+    private ApplicationRepository applicationRepository;
+
+    @MockBean
+    private BlogPostRepository blogPostRepository;
+
+    @MockBean
+    private ProjectRepository projectRepository;
+
+    private static final Long PROJECT_ID = 7L;
+
+    private RequestPostProcessor login(Long memberId, String role) {
+        UserInfo userInfo = UserInfo.builder()
+                .id(memberId)
+                .email("user" + memberId + "@test.com")
+                .role(role)
+                .build();
+        SnutLikeLionUser principal = SnutLikeLionUser.from(userInfo);
+        return SecurityMockMvcRequestPostProcessors.authentication(
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+    }
+
+    private String body(Long memberId, String content) throws Exception {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("memberId", memberId);
+        map.put("content", content);
+        return objectMapper.writeValueAsString(map);
+    }
+
+    // ── 위임(delegation) ────────────────────────────────────────────────
+
+    @Test
+    void createRetrospection_delegatesWithBodyMemberId_notLoginUserId() throws Exception {
+        // Given — 매니저(id=99)가 다른 멤버(id=42)의 회고를 등록
+        when(projectRetrospectionService.create(anyLong(), anyLong(), any()))
+                .thenReturn(RetrospectionResponse.builder().id(1L).content("내용").build());
+
+        // When & Then — 서비스에는 로그인 사용자(99)가 아니라 body의 memberId(42)가 위임돼야 한다
+        mockMvc.perform(post("/api/v1/projects/{projectId}/retrospections", PROJECT_ID)
+                        .with(login(99L, "ROLE_MANAGER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body(42L, "이번 프로젝트 회고")))
+                .andExpect(status().isCreated());
+
+        verify(projectRetrospectionService).create(eq(PROJECT_ID), eq(42L), any());
+    }
+}

--- a/src/test/java/com/snut_likelion/domain/project/service/ProjectRetrospectionServiceTest.java
+++ b/src/test/java/com/snut_likelion/domain/project/service/ProjectRetrospectionServiceTest.java
@@ -94,6 +94,49 @@ class ProjectRetrospectionServiceTest {
     }
 
     @Test
+    void create_usesGivenMemberIdAsWriter_notCaller() {
+        // Given — 호출자와 무관하게 전달받은 memberId(42)가 작성자/참여자/조회 기준이 되어야 한다
+        Long projectId = 1L;
+        Long memberId = 42L;
+        int generation = 14;
+
+        Project project = Project.builder()
+                .id(projectId).name("App").intro("소개").description("설명")
+                .generation(generation).category(ProjectCategory.HACKATHON).build();
+        project.setImages(List.of("images/projects/thumbnail.png"));
+
+        LionInfo lionInfo = mock(LionInfo.class);
+        when(lionInfo.getGeneration()).thenReturn(generation);
+        when(lionInfo.getPart()).thenReturn(Part.FRONTEND);
+
+        User writer = mock(User.class);
+        when(writer.getId()).thenReturn(memberId);
+        when(writer.getUsername()).thenReturn("대상멤버");
+        when(writer.getLionInfos()).thenReturn(List.of(lionInfo));
+
+        CreateRetrospectionRequest req = new CreateRetrospectionRequest("대상 멤버 회고");
+
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(project));
+        when(projectRetrospectionRepository.findByWriter_IdAndProject_Id(memberId, projectId))
+                .thenReturn(Optional.empty());
+        when(lionInfoRepository.findByUser_IdAndGeneration(memberId, generation))
+                .thenReturn(Optional.of(lionInfo));
+        when(userRepository.findById(memberId)).thenReturn(Optional.of(writer));
+
+        // When
+        RetrospectionResponse response = projectRetrospectionService.create(projectId, memberId, req);
+
+        // Then — 응답·생성된 회고·모든 조회가 caller가 아닌 memberId(42) 기준
+        assertThat(response.getWriter().getId()).isEqualTo(memberId);
+        assertThat(response.getWriter().getName()).isEqualTo("대상멤버");
+        assertThat(project.getRetrospections()).hasSize(1);
+        assertThat(project.getRetrospections().get(0).getWriter().getId()).isEqualTo(memberId);
+        verify(projectRetrospectionRepository).findByWriter_IdAndProject_Id(memberId, projectId);
+        verify(lionInfoRepository).findByUser_IdAndGeneration(memberId, generation);
+        verify(userRepository).findById(memberId);
+    }
+
+    @Test
     void create_projectNotFound_throwsNotFoundException() {
         // Given
         Long projectId = 99L;


### PR DESCRIPTION
## 개요
일반 프로젝트 회고 작성 엔드포인트가 어드민처럼 `memberId`를 받도록 변경합니다.
보안을 위해 **일반 사용자는 본인 회고만**, **매니저는 타 멤버 대리 등록** 가능하도록 `isMe` 인가 가드를 둡니다. (기존 '작성자=로그인 사용자' 고정 보호를 컨트롤러 `@PreAuthorize`로 이전)

## 🆕 API 변경 (프론트 참고)

**[POST] `/api/v1/projects/{projectId}/retrospections`** — 요청 body에 `memberId` 추가

```json
{
  "memberId": 42,
  "content": "이번 프로젝트에서 많이 배웠습니다."
}
```
> 🆕 `memberId` (Long, 필수) — 일반 사용자는 **본인 id만** 허용(타인 지정 시 403), 매니저는 타 멤버 지정 가능

응답 (201) — **변경 없음**
```json
{
  "code": "OK",
  "message": "프로젝트 회고 작성 성공",
  "data": {
    "id": 10,
    "content": "이번 프로젝트에서 많이 배웠습니다.",
    "writer": { "id": 42, "name": "홍길동", "part": "FRONTEND" }
  }
}
```

에러:
- `memberId` 누락 → **400**
- 일반 사용자가 타인 `memberId` 지정 → **403**

## 작업 내용 (커밋 단위로 분리)
- [x] DTO `memberId` 필드 추가 (`a411436`)
- [x] 컨트롤러 위임을 body `memberId` 기반으로 변경 (`0ea853d`)
- [x] `isMe` 인가 가드 — 타인 명의 작성 차단 (`afbd03d`)
- [x] `memberId` 필수 검증 `@NotNull` (`1f915f7`)
- [x] 서비스 시맨틱 검증 보강 테스트 (`79479bf`)

## 변경 유형
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [x] 테스트
- [ ] 문서

## 테스트 (TDD)
- [x] 단위 테스트 작성/확인 — 각 동작을 red→green으로 구현
  - 컨트롤러 `@WebMvcTest` 5: 위임(매니저 타멤버), 타인 **403**, 본인 **201**, memberId 누락 **400**, content 공백 **400**
  - 서비스 1: caller가 아닌 `memberId` 기준으로 writer/참여자/조회 수행 검증
- [x] 로컬 실행 확인 (`./gradlew test` → BUILD SUCCESSFUL, 전체 스위트 GREEN)

## DB 스키마
- **변경 없음** — `memberId`는 요청 DTO 전용(영속화 X). 별도 마이그레이션 불필요.

## 관련 이슈
closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)